### PR TITLE
refactor: 카테고리 테이블 구조 변경

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/item/mapper/CategoryMybatisMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/mapper/CategoryMybatisMapper.java
@@ -1,0 +1,10 @@
+package com.biddingmate.biddinggo.item.mapper;
+
+import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.item.model.Category;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CategoryMybatisMapper extends IMybatisCRUD<Category> {
+    Category findById(Long id);
+}

--- a/src/main/java/com/biddingmate/biddinggo/item/model/Category.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/model/Category.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Builder
 public class Category {
     private Long id;
-    private String large;
-    private String mid;
-    private String small;
+    private Long parentId;
+    private String name;
+    private Integer level;
 }

--- a/src/main/resources/db/migration/V3__refactor_category_to_hierarchy.sql
+++ b/src/main/resources/db/migration/V3__refactor_category_to_hierarchy.sql
@@ -1,0 +1,55 @@
+-- =====================================================
+-- CATEGORY HIERARCHY REFACTOR
+-- - 기존 로컬 auction 도메인 데이터는 유지하지 않는다.
+-- - category를 parent-child 계층 구조로 재정의한다.
+-- =====================================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE review;
+TRUNCATE TABLE winner_deal;
+TRUNCATE TABLE point_history;
+TRUNCATE TABLE wishlist;
+TRUNCATE TABLE auction_inquiry;
+TRUNCATE TABLE bid;
+TRUNCATE TABLE auction;
+TRUNCATE TABLE inspection;
+TRUNCATE TABLE item_image;
+TRUNCATE TABLE auction_item;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+SET @category_fk_name = (
+    SELECT CONSTRAINT_NAME
+    FROM information_schema.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'auction_item'
+      AND COLUMN_NAME = 'category_id'
+      AND REFERENCED_TABLE_NAME = 'category'
+    LIMIT 1
+);
+
+SET @drop_category_fk_sql = IF(
+    @category_fk_name IS NOT NULL,
+    CONCAT('ALTER TABLE auction_item DROP FOREIGN KEY ', @category_fk_name),
+    'SELECT 1'
+);
+
+PREPARE drop_category_fk_stmt FROM @drop_category_fk_sql;
+EXECUTE drop_category_fk_stmt;
+DEALLOCATE PREPARE drop_category_fk_stmt;
+
+DROP TABLE category;
+
+CREATE TABLE category (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    parent_id BIGINT NULL,
+    name VARCHAR(50) NOT NULL,
+    level INT NOT NULL CHECK (level IN (1, 2, 3)),
+    INDEX idx_category_parent_id (parent_id),
+    CONSTRAINT fk_category_parent FOREIGN KEY (parent_id) REFERENCES category(id)
+);
+
+ALTER TABLE auction_item
+    ADD CONSTRAINT fk_auction_item_category
+        FOREIGN KEY (category_id) REFERENCES category(id);

--- a/src/main/resources/mapper/item/category-mapper.xml
+++ b/src/main/resources/mapper/item/category-mapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.biddingmate.biddinggo.item.mapper.CategoryMybatisMapper">
+
+    <resultMap id="categoryResultMap" type="Category">
+        <id property="id" column="id"/>
+        <result property="parentId" column="parent_id"/>
+        <result property="name" column="name"/>
+        <result property="level" column="level"/>
+    </resultMap>
+
+    <select id="findById" parameterType="long" resultMap="categoryResultMap">
+        SELECT
+            id,
+            parent_id,
+            name,
+            level
+        FROM category
+        WHERE id = #{id}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌 PR 유형

  - [ ] Feature (새로운 기능 추가)
  - [ ] Fix (버그 수정)
  - [x] Refactor (코드 리팩토링)
  - [x] Chore (유지보수, 의존성 업데이트 등)
  - [ ] Docs (문서 작성/수정)

  ———

  ## 📝 작업 내용

  - category 구조를 large/mid/small 컬럼 기반에서 parent_id, name, level 기반 계층형 구조로 전환하기 위한 migration 추가
  - 로컬 데이터 이관은 고려하지 않고, category 관련 구조를 새 기준으로 재구성하는 방향으로 migration 설계
  - Category 모델을 새 스키마에 맞게 수정
      - id
      - parentId
      - name
      - level
  - 카테고리 단건 조회용 MyBatis mapper 추가
      - CategoryMybatisMapper
      - findById(Long id)
  - category 조회 XML 추가
      - 새 계층형 category 컬럼 기준 매핑 정의

  ———

  ## 📎 관련 이슈

  - #24 