### PR TITLE
feat: 경매 상세 조회 API 

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
@@ -1,8 +1,10 @@
 package com.biddingmate.biddinggo.auction.controller;
 
+import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionResponse;
 import com.biddingmate.biddinggo.auction.service.AuctionApplicationService;
+import com.biddingmate.biddinggo.auction.service.AuctionQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -10,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +25,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Auction", description = "경매 등록 API")
 public class AuctionController {
     private final AuctionApplicationService auctionApplicationService;
+    private final AuctionQueryService auctionQueryService;
+
+    @GetMapping("/{auctionId}")
+    @Operation(summary = "경매 상세 조회", description = "경매 기본 정보, 상품 정보, 카테고리, 이미지 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<AuctionDetailResponse>> getAuctionDetail(
+            @PathVariable Long auctionId) {
+
+        AuctionDetailResponse result = auctionQueryService.getAuctionDetail(auctionId);
+
+        return ApiResponse.of(HttpStatus.OK, null, "경매 상세 조회 완료", result);
+    }
 
     @PostMapping("")
     @Operation(summary = "경매 등록", description = "경매 상품과 경매 정보를 함께 등록합니다.")

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionDetailResponse.java
@@ -1,0 +1,130 @@
+package com.biddingmate.biddinggo.auction.dto;
+
+import com.biddingmate.biddinggo.auction.model.AuctionStatus;
+import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.auction.model.YesNo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "경매 상세 조회 응답 DTO")
+public class AuctionDetailResponse {
+    @Schema(description = "경매 ID", example = "1")
+    private Long auctionId;
+
+    @Schema(description = "판매자 ID", example = "1")
+    private Long sellerId;
+
+    @Schema(description = "경매 상태", example = "ON_GOING")
+    private AuctionStatus status;
+
+    @Schema(description = "경매 타입", example = "NORMAL")
+    private AuctionType type;
+
+    @Schema(description = "검수 여부", example = "NO")
+    private YesNo inspectionYn;
+
+    @Schema(description = "시작가", example = "100000")
+    private Long startPrice;
+
+    @Schema(description = "입찰 단위", example = "1000")
+    private Integer bidUnit;
+
+    @Schema(description = "비크리 가격", example = "150000", nullable = true)
+    private Long vickreyPrice;
+
+    @Schema(description = "즉시 구매가", example = "180000", nullable = true)
+    private Long buyNowPrice;
+
+    @Schema(description = "입찰 수", example = "0")
+    private Integer bidCount;
+
+    @Schema(description = "찜 수", example = "0")
+    private Integer wishCount;
+
+    @Schema(description = "경매 시작일시")
+    private LocalDateTime startDate;
+
+    @Schema(description = "경매 종료일시")
+    private LocalDateTime endDate;
+
+    @Schema(description = "경매 취소일시", nullable = true)
+    private LocalDateTime cancelDate;
+
+    @Schema(description = "경매 생성일시")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "상품 정보")
+    private Item item;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "경매 상품 정보")
+    public static class Item {
+        @Schema(description = "상품 ID", example = "10")
+        private Long itemId;
+
+        @Schema(description = "브랜드명", example = "Nike")
+        private String brand;
+
+        @Schema(description = "상품명", example = "Air Jordan 1 High")
+        private String name;
+
+        @Schema(description = "상품 상태", example = "최상")
+        private String quality;
+
+        @Schema(description = "상품 설명", example = "실착 2회, 박스 포함")
+        private String description;
+
+        @Schema(description = "카테고리 정보")
+        private Category category;
+
+        @Schema(description = "상품 이미지 목록")
+        private List<Image> images;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "카테고리 정보")
+    public static class Category {
+        @Schema(description = "카테고리 ID", example = "100")
+        private Long id;
+
+        @Schema(description = "카테고리명", example = "하이탑")
+        private String name;
+
+        @Schema(description = "카테고리 level", example = "3")
+        private Integer level;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "상품 이미지 정보")
+    public static class Image {
+        @Schema(description = "이미지 URL")
+        private String url;
+
+        @Schema(description = "노출 순서", example = "1")
+        private Integer displayOrder;
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/CreateAuctionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/CreateAuctionRequest.java
@@ -67,6 +67,7 @@ public class CreateAuctionRequest {
         private String description;
 
         @Schema(description = "상품 이미지 목록")
+        @Size(max = 10, message = "상품 이미지는 최대 10장까지 등록할 수 있습니다.")
         private List<@Valid @NotNull(message = "이미지 정보는 null일 수 없습니다.") Image> images;
     }
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -6,6 +6,6 @@ import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
-public interface AuctionMybatisMapper extends IMybatisCRUD<Auction> {
+public interface AuctionMapper extends IMybatisCRUD<Auction> {
     AuctionDetailResponse findDetailById(Long auctionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMybatisMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMybatisMapper.java
@@ -1,9 +1,11 @@
 package com.biddingmate.biddinggo.auction.mapper;
 
+import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface AuctionMybatisMapper extends IMybatisCRUD<Auction> {
+    AuctionDetailResponse findDetailById(Long auctionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
@@ -2,6 +2,13 @@ package com.biddingmate.biddinggo.auction.service;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 
+/**
+ * 경매 조회 전용 서비스.
+ * 등록/수정 로직과 분리하여 읽기 책임만 담당한다.
+ */
 public interface AuctionQueryService {
+    /**
+     * 경매 ID를 기준으로 상세 정보를 조회한다.
+     */
     AuctionDetailResponse getAuctionDetail(Long auctionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.auction.service;
+
+import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+
+public interface AuctionQueryService {
+    AuctionDetailResponse getAuctionDetail(Long auctionId);
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -1,0 +1,38 @@
+package com.biddingmate.biddinggo.auction.service;
+
+import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.auction.mapper.AuctionMybatisMapper;
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.item.mapper.ItemImageMybatisMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionQueryServiceImpl implements AuctionQueryService {
+    private final AuctionMybatisMapper auctionMybatisMapper;
+    private final ItemImageMybatisMapper itemImageMybatisMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuctionDetailResponse getAuctionDetail(Long auctionId) {
+        if (auctionId == null || auctionId <= 0) {
+            throw new CustomException(ErrorType.BAD_REQUEST);
+        }
+
+        AuctionDetailResponse detail = auctionMybatisMapper.findDetailById(auctionId);
+
+        if (detail == null) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
+        }
+
+        List<AuctionDetailResponse.Image> images = itemImageMybatisMapper.findDetailImagesByItemId(detail.getItem().getItemId());
+        detail.getItem().setImages(images);
+
+        return detail;
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -11,6 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+/**
+ * 경매 상세 조회 구현체.
+ * 본문 정보와 이미지 목록을 분리 조회한 뒤 하나의 응답 DTO로 조합한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class AuctionQueryServiceImpl implements AuctionQueryService {
@@ -19,17 +23,25 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    /**
+     * 경매 상세 조회 메인 로직.
+     * 1) 경매/상품/카테고리 본문 조회
+     * 2) item_image 목록 조회
+     * 3) 이미지 목록을 응답 객체에 조합
+     */
     public AuctionDetailResponse getAuctionDetail(Long auctionId) {
         if (auctionId == null || auctionId <= 0) {
             throw new CustomException(ErrorType.BAD_REQUEST);
         }
 
+        // 경매 기본 정보와 상품 본문 정보를 먼저 조회한다.
         AuctionDetailResponse detail = auctionMybatisMapper.findDetailById(auctionId);
 
         if (detail == null) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
         }
 
+        // item_id 기준으로 이미지 목록을 별도 조회해 노출 순서대로 붙인다.
         List<AuctionDetailResponse.Image> images = itemImageMybatisMapper.findDetailImagesByItemId(detail.getItem().getItemId());
         detail.getItem().setImages(images);
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -1,10 +1,10 @@
 package com.biddingmate.biddinggo.auction.service;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
-import com.biddingmate.biddinggo.auction.mapper.AuctionMybatisMapper;
+import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
-import com.biddingmate.biddinggo.item.mapper.ItemImageMybatisMapper;
+import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,8 +18,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AuctionQueryServiceImpl implements AuctionQueryService {
-    private final AuctionMybatisMapper auctionMybatisMapper;
-    private final ItemImageMybatisMapper itemImageMybatisMapper;
+    private final AuctionMapper auctionMapper;
+    private final ItemImageMapper itemImageMapper;
 
     @Override
     @Transactional(readOnly = true)
@@ -35,14 +35,14 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         }
 
         // 경매 기본 정보와 상품 본문 정보를 먼저 조회한다.
-        AuctionDetailResponse detail = auctionMybatisMapper.findDetailById(auctionId);
+        AuctionDetailResponse detail = auctionMapper.findDetailById(auctionId);
 
         if (detail == null) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
         }
 
         // item_id 기준으로 이미지 목록을 별도 조회해 노출 순서대로 붙인다.
-        List<AuctionDetailResponse.Image> images = itemImageMybatisMapper.findDetailImagesByItemId(detail.getItem().getItemId());
+        List<AuctionDetailResponse.Image> images = itemImageMapper.findDetailImagesByItemId(detail.getItem().getItemId());
         detail.getItem().setImages(images);
 
         return detail;

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
@@ -1,7 +1,7 @@
 package com.biddingmate.biddinggo.auction.service;
 
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
-import com.biddingmate.biddinggo.auction.mapper.AuctionMybatisMapper;
+import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 public class AuctionServiceImpl implements AuctionService {
-    private final AuctionMybatisMapper auctionMybatisMapper;
+    private final AuctionMapper auctionMapper;
 
     @Override
     public Long createAuction(CreateAuctionRequest request, Long itemId) {
@@ -41,7 +41,7 @@ public class AuctionServiceImpl implements AuctionService {
                 .build();
 
         // auction 저장 후 생성된 PK를 모델에 주입받는다.
-        int auctionInsertCount = auctionMybatisMapper.insert(auction);
+        int auctionInsertCount = auctionMapper.insert(auction);
 
         if (auctionInsertCount != 1 || auction.getId() == null) {
             throw new CustomException(ErrorType.AUCTION_SAVE_FAILED);

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -31,6 +31,7 @@ public enum ErrorType {
     AUCTION_SAVE_FAILED("auction-003", "경매 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ITEM_IMAGE_SAVE_FAILED("auction-004", "상품 이미지 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     DUPLICATE_ITEM_IMAGE_DISPLAY_ORDER("auction-005", "상품 이미지 노출 순서는 중복될 수 없습니다.", HttpStatus.BAD_REQUEST),
+    AUCTION_NOT_FOUND("auction-006", "경매를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -32,6 +32,8 @@ public enum ErrorType {
     ITEM_IMAGE_SAVE_FAILED("auction-004", "상품 이미지 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     DUPLICATE_ITEM_IMAGE_DISPLAY_ORDER("auction-005", "상품 이미지 노출 순서는 중복될 수 없습니다.", HttpStatus.BAD_REQUEST),
     AUCTION_NOT_FOUND("auction-006", "경매를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CATEGORY_NOT_FOUND("auction-007", "카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_CATEGORY_LEVEL("auction-008", "최하위 카테고리만 선택할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/item/mapper/AuctionItemMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/mapper/AuctionItemMapper.java
@@ -1,10 +1,9 @@
 package com.biddingmate.biddinggo.item.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
-import com.biddingmate.biddinggo.item.model.Category;
+import com.biddingmate.biddinggo.item.model.AuctionItem;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
-public interface CategoryMybatisMapper extends IMybatisCRUD<Category> {
-    Category findById(Long id);
+public interface AuctionItemMapper extends IMybatisCRUD<AuctionItem> {
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/mapper/CategoryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/mapper/CategoryMapper.java
@@ -1,9 +1,10 @@
 package com.biddingmate.biddinggo.item.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
-import com.biddingmate.biddinggo.item.model.AuctionItem;
+import com.biddingmate.biddinggo.item.model.Category;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
-public interface AuctionItemMybatisMapper extends IMybatisCRUD<AuctionItem> {
+public interface CategoryMapper extends IMybatisCRUD<Category> {
+    Category findById(Long id);
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/mapper/ItemImageMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/mapper/ItemImageMapper.java
@@ -8,6 +8,6 @@ import org.apache.ibatis.annotations.Mapper;
 import java.util.List;
 
 @Mapper
-public interface ItemImageMybatisMapper extends IMybatisCRUD<ItemImage> {
+public interface ItemImageMapper extends IMybatisCRUD<ItemImage> {
     List<AuctionDetailResponse.Image> findDetailImagesByItemId(Long itemId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/mapper/ItemImageMybatisMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/mapper/ItemImageMybatisMapper.java
@@ -1,9 +1,13 @@
 package com.biddingmate.biddinggo.item.mapper;
 
+import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import com.biddingmate.biddinggo.item.model.ItemImage;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 @Mapper
 public interface ItemImageMybatisMapper extends IMybatisCRUD<ItemImage> {
+    List<AuctionDetailResponse.Image> findDetailImagesByItemId(Long itemId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
@@ -4,7 +4,9 @@ import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMybatisMapper;
+import com.biddingmate.biddinggo.item.mapper.CategoryMybatisMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
+import com.biddingmate.biddinggo.item.model.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,14 +14,28 @@ import java.time.LocalDateTime;
 
 /**
  * auction_item 엔티티 생성만 담당하는 서비스 구현체.
+ * 경매 등록 시 선택한 카테고리가 실제 최하위 카테고리인지 함께 검증한다.
  */
 @Service
 @RequiredArgsConstructor
 public class AuctionItemServiceImpl implements AuctionItemService {
     private final AuctionItemMybatisMapper auctionItemMybatisMapper;
+    private final CategoryMybatisMapper categoryMybatisMapper;
 
     @Override
     public Long createAuctionItem(CreateAuctionRequest request) {
+        // 등록 요청에서 선택한 categoryId가 실제 존재하는지 확인한다.
+        Category category = categoryMybatisMapper.findById(request.getItem().getCategoryId());
+
+        if (category == null) {
+            throw new CustomException(ErrorType.CATEGORY_NOT_FOUND);
+        }
+
+        // 현재 정책상 경매 등록은 최하위(level=3) 카테고리만 허용한다.
+        if (!Integer.valueOf(3).equals(category.getLevel())) {
+            throw new CustomException(ErrorType.INVALID_CATEGORY_LEVEL);
+        }
+
         // request를 DB 저장용 auction_item 모델로 변환한다.
         AuctionItem auctionItem = AuctionItem.builder()
                 .sellerId(request.getItem().getSellerId())

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
@@ -3,8 +3,8 @@ package com.biddingmate.biddinggo.item.service;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
-import com.biddingmate.biddinggo.item.mapper.AuctionItemMybatisMapper;
-import com.biddingmate.biddinggo.item.mapper.CategoryMybatisMapper;
+import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
+import com.biddingmate.biddinggo.item.mapper.CategoryMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.Category;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +19,13 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 public class AuctionItemServiceImpl implements AuctionItemService {
-    private final AuctionItemMybatisMapper auctionItemMybatisMapper;
-    private final CategoryMybatisMapper categoryMybatisMapper;
+    private final AuctionItemMapper auctionItemMapper;
+    private final CategoryMapper categoryMapper;
 
     @Override
     public Long createAuctionItem(CreateAuctionRequest request) {
         // 등록 요청에서 선택한 categoryId가 실제 존재하는지 확인한다.
-        Category category = categoryMybatisMapper.findById(request.getItem().getCategoryId());
+        Category category = categoryMapper.findById(request.getItem().getCategoryId());
 
         if (category == null) {
             throw new CustomException(ErrorType.CATEGORY_NOT_FOUND);
@@ -48,7 +48,7 @@ public class AuctionItemServiceImpl implements AuctionItemService {
                 .build();
 
         // auction_item 저장 후 생성된 PK를 모델에 주입받는다.
-        int itemInsertCount = auctionItemMybatisMapper.insert(auctionItem);
+        int itemInsertCount = auctionItemMapper.insert(auctionItem);
 
         if (itemInsertCount != 1 || auctionItem.getId() == null) {
             throw new CustomException(ErrorType.AUCTION_ITEM_SAVE_FAILED);

--- a/src/main/java/com/biddingmate/biddinggo/item/service/ItemImageServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/ItemImageServiceImpl.java
@@ -5,7 +5,7 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.file.model.FileMetadata;
 import com.biddingmate.biddinggo.file.service.FileService;
-import com.biddingmate.biddinggo.item.mapper.ItemImageMybatisMapper;
+import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
 import com.biddingmate.biddinggo.item.model.ItemImage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class ItemImageServiceImpl implements ItemImageService {
     private final FileService fileService;
-    private final ItemImageMybatisMapper itemImageMybatisMapper;
+    private final ItemImageMapper itemImageMapper;
 
     @Override
     /**
@@ -58,7 +58,7 @@ public class ItemImageServiceImpl implements ItemImageService {
                     .createdAt(LocalDateTime.now())
                     .build();
 
-            int imageInsertCount = itemImageMybatisMapper.insert(itemImage);
+            int imageInsertCount = itemImageMapper.insert(itemImage);
 
             if (imageInsertCount != 1 || itemImage.getId() == null) {
                 throw new CustomException(ErrorType.ITEM_IMAGE_SAVE_FAILED);

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.biddingmate.biddinggo.auction.mapper.AuctionMybatisMapper">
+<mapper namespace="com.biddingmate.biddinggo.auction.mapper.AuctionMapper">
 
     <resultMap id="auctionDetailResultMap" type="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse">
         <id property="auctionId" column="auction_id"/>

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -3,6 +3,36 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.biddingmate.biddinggo.auction.mapper.AuctionMybatisMapper">
 
+    <resultMap id="auctionDetailResultMap" type="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse">
+        <id property="auctionId" column="auction_id"/>
+        <result property="sellerId" column="seller_id"/>
+        <result property="status" column="status"/>
+        <result property="type" column="type"/>
+        <result property="inspectionYn" column="inspection_yn"/>
+        <result property="startPrice" column="start_price"/>
+        <result property="bidUnit" column="bid_unit"/>
+        <result property="vickreyPrice" column="vickrey_price"/>
+        <result property="buyNowPrice" column="buy_now_price"/>
+        <result property="bidCount" column="bid_count"/>
+        <result property="wishCount" column="wish_count"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="cancelDate" column="cancel_date"/>
+        <result property="createdAt" column="created_at"/>
+        <association property="item" javaType="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse$Item">
+            <id property="itemId" column="item_id"/>
+            <result property="brand" column="brand"/>
+            <result property="name" column="name"/>
+            <result property="quality" column="quality"/>
+            <result property="description" column="description"/>
+            <association property="category" javaType="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse$Category">
+                <id property="id" column="category_id"/>
+                <result property="name" column="category_name"/>
+                <result property="level" column="category_level"/>
+            </association>
+        </association>
+    </resultMap>
+
     <insert id="insert" parameterType="Auction" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO auction
         <trim prefix="(" suffix=")" suffixOverrides=",">
@@ -44,5 +74,36 @@
             #{createdAt}
         </trim>
     </insert>
+
+    <select id="findDetailById" parameterType="long" resultMap="auctionDetailResultMap">
+        SELECT
+            a.id AS auction_id,
+            a.seller_id,
+            a.type,
+            a.inspection_yn,
+            a.status,
+            a.start_price,
+            a.bid_unit,
+            a.vickrey_price,
+            a.buy_now_price,
+            a.bid_count,
+            a.wish_count,
+            a.start_date,
+            a.end_date,
+            a.cancel_date,
+            a.created_at,
+            ai.id AS item_id,
+            ai.brand,
+            ai.name,
+            ai.quality,
+            ai.description,
+            c3.id AS category_id,
+            c3.name AS category_name,
+            c3.level AS category_level
+        FROM auction a
+        INNER JOIN auction_item ai ON a.item_id = ai.id
+        INNER JOIN category c3 ON ai.category_id = c3.id
+        WHERE a.id = #{auctionId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/item/auction-item-mapper.xml
+++ b/src/main/resources/mapper/item/auction-item-mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.biddingmate.biddinggo.item.mapper.AuctionItemMybatisMapper">
+<mapper namespace="com.biddingmate.biddinggo.item.mapper.AuctionItemMapper">
 
     <insert id="insert" parameterType="AuctionItem" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO auction_item

--- a/src/main/resources/mapper/item/category-mapper.xml
+++ b/src/main/resources/mapper/item/category-mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.biddingmate.biddinggo.item.mapper.CategoryMybatisMapper">
+<mapper namespace="com.biddingmate.biddinggo.item.mapper.CategoryMapper">
 
     <resultMap id="categoryResultMap" type="Category">
         <id property="id" column="id"/>

--- a/src/main/resources/mapper/item/item-image-mapper.xml
+++ b/src/main/resources/mapper/item/item-image-mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.biddingmate.biddinggo.item.mapper.ItemImageMybatisMapper">
+<mapper namespace="com.biddingmate.biddinggo.item.mapper.ItemImageMapper">
 
     <resultMap id="auctionDetailImageResultMap" type="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse$Image">
         <result property="url" column="url"/>

--- a/src/main/resources/mapper/item/item-image-mapper.xml
+++ b/src/main/resources/mapper/item/item-image-mapper.xml
@@ -3,6 +3,11 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.biddingmate.biddinggo.item.mapper.ItemImageMybatisMapper">
 
+    <resultMap id="auctionDetailImageResultMap" type="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse$Image">
+        <result property="url" column="url"/>
+        <result property="displayOrder" column="display_order"/>
+    </resultMap>
+
     <insert id="insert" parameterType="ItemImage" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO item_image(
             item_id,
@@ -20,5 +25,14 @@
             #{createdAt}
         )
     </insert>
+
+    <select id="findDetailImagesByItemId" parameterType="long" resultMap="auctionDetailImageResultMap">
+        SELECT
+            url,
+            display_order
+        FROM item_image
+        WHERE item_id = #{itemId}
+        ORDER BY display_order ASC
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형

  - [x] Feature (새로운 기능 추가)
  - [ ] Fix (버그 수정)
  - [ ] Refactor (코드 리팩토링)
  - [ ] Chore (유지보수, 의존성 업데이트 등)
  - [ ] Docs (문서 작성/수정)

  ———

  ## 📝 작업 내용

  - 경매 상세 조회 API GET /api/v1/auctions/{auctionId} 추가
  - 경매 상세 조회 응답 DTO AuctionDetailResponse 추가
  - 조회 전용 서비스 AuctionQueryService, AuctionQueryServiceImpl 추가
  - AuctionMybatisMapper에 경매 상세 조회 메서드 추가
  - ItemImageMybatisMapper에 상품 이미지 목록 조회 메서드 추가 - 상세 조회 응답에 판매자 정보는 sellerId만 포함
  - 상세 조회 응답의 카테고리는 최종 카테고리 하나만 반환하도록 구성
      - category.id
      - category.name
      - category.level
  - 상품 이미지 목록은 display_order ASC로 정렬해서 반환
  - 존재하지 않는 경매 조회 시 AUCTION_NOT_FOUND 예외 추가

  ———

  ## 📎 관련 이슈

  - #23 