### PR TITLE
feat: 검수 등록 API

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/CreateAuctionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/CreateAuctionRequest.java
@@ -2,6 +2,8 @@ package com.biddingmate.biddinggo.auction.dto;
 
 import com.biddingmate.biddinggo.auction.model.AuctionType;
 import com.biddingmate.biddinggo.auction.model.YesNo;
+import com.biddingmate.biddinggo.item.dto.AuctionItemCreateSource;
+import com.biddingmate.biddinggo.item.dto.ItemImageCreateSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -41,7 +43,7 @@ public class CreateAuctionRequest {
     @AllArgsConstructor
     @Builder
     @Schema(description = "경매 상품 요청 DTO")
-    public static class Item {
+    public static class Item implements AuctionItemCreateSource {
         @Schema(description = "판매자 ID", example = "1")
         @NotNull(message = "판매자 ID는 필수입니다.")
         private Long sellerId;
@@ -77,7 +79,7 @@ public class CreateAuctionRequest {
     @AllArgsConstructor
     @Builder
     @Schema(description = "상품 이미지 요청 DTO")
-    public static class Image {
+    public static class Image implements ItemImageCreateSource {
         @Schema(description = "R2에 업로드된 임시 파일 key", example = "temp/items/2026/03/13/uuid.jpg")
         @NotBlank(message = "파일 key는 필수입니다.")
         private String fileKey;

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionApplicationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionApplicationServiceImpl.java
@@ -39,7 +39,7 @@ public class AuctionApplicationServiceImpl implements AuctionApplicationService 
             validateRequest(request);
 
             // 1. auction_item 먼저 생성하여 itemId를 확보한다.
-            Long itemId = auctionItemService.createAuctionItem(request);
+            Long itemId = auctionItemService.createAuctionItem(request.getItem());
 
             // 2. 업로드된 이미지 메타데이터를 item_image에 저장한다.
             itemImageService.createItemImages(itemId, request.getItem().getImages());

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -38,6 +38,10 @@ public enum ErrorType {
     CATEGORY_NOT_FOUND("auction-007", "카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_CATEGORY_LEVEL("auction-008", "최하위 카테고리만 선택할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
+    // 검수
+    INVALID_INSPECTION_CREATE_REQUEST("inspection-001", "검수 등록 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INSPECTION_SAVE_FAILED("inspection-002", "검수 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     R2_PRESIGNED_URL_GENERATION_FAILED("file-002", "R2 업로드 URL 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
+++ b/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/payments/**", "/api/v1/auctions/**", "/api/v1/files/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/payments/**", "/api/v1/auctions/**", "/api/v1/files/**", "/api/v1/inspections/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated());
 
 

--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
@@ -1,0 +1,38 @@
+package com.biddingmate.biddinggo.inspection.controller;
+
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+import com.biddingmate.biddinggo.inspection.dto.CreateInspectionResponse;
+import com.biddingmate.biddinggo.inspection.service.InspectionApplicationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/inspections")
+@RequiredArgsConstructor
+@Tag(name = "Inspection", description = "상품 검수 등록 API")
+public class InspectionController {
+    private final InspectionApplicationService inspectionApplicationService;
+
+    @PostMapping("")
+    @Operation(summary = "상품 검수 등록", description = "검수 대상 상품, 이미지, 검수 정보를 함께 등록합니다.")
+    public ResponseEntity<ApiResponse<CreateInspectionResponse>> createInspection(
+            @Valid @RequestBody CreateInspectionRequest request) {
+
+        Long inspectionId = inspectionApplicationService.createInspection(request);
+
+        CreateInspectionResponse result = CreateInspectionResponse.builder()
+                .inspectionId(inspectionId)
+                .build();
+
+        return ApiResponse.of(HttpStatus.OK, null, "상품 검수 등록 완료", result);
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/CreateInspectionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/CreateInspectionRequest.java
@@ -1,5 +1,7 @@
 package com.biddingmate.biddinggo.inspection.dto;
 
+import com.biddingmate.biddinggo.item.dto.AuctionItemCreateSource;
+import com.biddingmate.biddinggo.item.dto.ItemImageCreateSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -36,7 +38,7 @@ public class CreateInspectionRequest {
     @AllArgsConstructor
     @Builder
     @Schema(description = "검수 대상 상품 요청 DTO")
-    public static class Item {
+    public static class Item implements AuctionItemCreateSource {
         @Schema(description = "판매자 ID", example = "1")
         @NotNull(message = "판매자 ID는 필수입니다.")
         private Long sellerId;
@@ -72,7 +74,7 @@ public class CreateInspectionRequest {
     @AllArgsConstructor
     @Builder
     @Schema(description = "상품 이미지 요청 DTO")
-    public static class Image {
+    public static class Image implements ItemImageCreateSource {
         @Schema(description = "R2에 업로드된 임시 파일 key", example = "temp/items/2026/03/13/uuid.jpg")
         @NotBlank(message = "파일 key는 필수입니다.")
         private String fileKey;

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/CreateInspectionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/CreateInspectionRequest.java
@@ -1,0 +1,101 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "상품 검수 등록 요청 DTO")
+public class CreateInspectionRequest {
+    @Schema(description = "검수 대상 상품 정보")
+    @NotNull(message = "상품 정보는 필수입니다.")
+    @Valid
+    private Item item;
+
+    @Schema(description = "검수 발송 정보")
+    @Valid
+    private Inspection inspection;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "검수 대상 상품 요청 DTO")
+    public static class Item {
+        @Schema(description = "판매자 ID", example = "1")
+        @NotNull(message = "판매자 ID는 필수입니다.")
+        private Long sellerId;
+
+        @Schema(description = "카테고리 ID", example = "10")
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        private Long categoryId;
+
+        @Schema(description = "브랜드명", example = "Nike")
+        @Size(max = 50, message = "브랜드명은 50자 이하여야 합니다.")
+        private String brand;
+
+        @Schema(description = "상품명", example = "Air Jordan 1 High")
+        @NotBlank(message = "상품명은 필수입니다.")
+        @Size(max = 50, message = "상품명은 50자 이하여야 합니다.")
+        private String name;
+
+        @Schema(description = "상품 상태", example = "최상")
+        @Size(max = 20, message = "상품 상태는 20자 이하여야 합니다.")
+        private String quality;
+
+        @Schema(description = "상품 설명", example = "실착 2회, 박스 포함")
+        private String description;
+
+        @Schema(description = "상품 이미지 목록")
+        @Size(max = 10, message = "상품 이미지는 최대 10장까지 등록할 수 있습니다.")
+        private List<@Valid @NotNull(message = "이미지 정보는 null일 수 없습니다.") Image> images;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "상품 이미지 요청 DTO")
+    public static class Image {
+        @Schema(description = "R2에 업로드된 임시 파일 key", example = "temp/items/2026/03/13/uuid.jpg")
+        @NotBlank(message = "파일 key는 필수입니다.")
+        private String fileKey;
+
+        @Schema(description = "이미지 노출 순서", example = "1")
+        @NotNull(message = "이미지 노출 순서는 필수입니다.")
+        @Positive(message = "이미지 노출 순서는 1 이상이어야 합니다.")
+        private Integer displayOrder;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "검수 발송 정보")
+    public static class Inspection {
+        @Schema(description = "택배사", example = "CJ대한통운", nullable = true)
+        @Size(max = 20, message = "택배사는 20자 이하여야 합니다.")
+        private String carrier;
+
+        @Schema(description = "송장 번호", example = "1234567890", nullable = true)
+        @Size(max = 255, message = "송장 번호는 255자 이하여야 합니다.")
+        private String trackingNumber;
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/CreateInspectionResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/CreateInspectionResponse.java
@@ -1,0 +1,15 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "상품 검수 등록 응답 DTO")
+public class CreateInspectionResponse {
+    @Schema(description = "생성된 검수 ID", example = "12")
+    private Long inspectionId;
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
@@ -1,0 +1,9 @@
+package com.biddingmate.biddinggo.inspection.mapper;
+
+import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.inspection.model.Inspection;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface InspectionMapper extends IMybatisCRUD<Inspection> {
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/model/Inspection.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/model/Inspection.java
@@ -1,0 +1,26 @@
+package com.biddingmate.biddinggo.inspection.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Inspection {
+    private Long id;
+    private Long itemId;
+    private LocalDateTime receivedAt;
+    private InspectionStatus status;
+    private LocalDateTime completedAt;
+    private String failureReason;
+    private String carrier;
+    private String trackingNumber;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/model/InspectionStatus.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/model/InspectionStatus.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.inspection.model;
+
+public enum InspectionStatus {
+    PENDING,
+    PASSED,
+    FAILED
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionApplicationService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionApplicationService.java
@@ -1,0 +1,14 @@
+package com.biddingmate.biddinggo.inspection.service;
+
+import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+
+/**
+ * 상품 검수 등록 유스케이스를 조합하는 상위 서비스.
+ * 컨트롤러는 이 서비스를 통해 검수 등록을 시작한다.
+ */
+public interface InspectionApplicationService {
+    /**
+     * 검수 대상 상품 생성, 이미지 저장, inspection 생성을 하나의 흐름으로 처리한다.
+     */
+    Long createInspection(CreateInspectionRequest request);
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionApplicationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionApplicationServiceImpl.java
@@ -1,0 +1,66 @@
+package com.biddingmate.biddinggo.inspection.service;
+
+import com.biddingmate.biddinggo.file.service.FileService;
+import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+import com.biddingmate.biddinggo.item.service.AuctionItemService;
+import com.biddingmate.biddinggo.item.service.ItemImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 검수 등록 전체 흐름을 조율하는 애플리케이션 서비스.
+ * 트랜잭션 경계는 이 클래스에서만 관리한다.
+ * auction_item, item_image, inspection 생성을 하나의 유스케이스로 묶는다.
+ */
+@Service
+@RequiredArgsConstructor
+public class InspectionApplicationServiceImpl implements InspectionApplicationService {
+    private final AuctionItemService auctionItemService;
+    private final ItemImageService itemImageService;
+    private final InspectionService inspectionService;
+    private final FileService fileService;
+
+    @Override
+    @Transactional
+    /**
+     * 검수 등록 메인 플로우.
+     * 업로드된 임시 파일 목록을 먼저 확보해두고,
+     * 중간 실패 시 R2 cleanup까지 함께 처리한다.
+     */
+    public Long createInspection(CreateInspectionRequest request) {
+        List<String> uploadedFileKeys = extractUploadedFileKeys(request);
+
+        try {
+            // 1. 검수 대상 상품을 먼저 생성하여 itemId를 확보한다.
+            Long itemId = auctionItemService.createInspectionItem(request.getItem());
+
+            // 2. 업로드된 이미지 메타데이터를 item_image에 저장한다.
+            itemImageService.createItemImages(itemId, request.getItem().getImages());
+
+            // 3. 생성된 itemId로 inspection 레코드를 생성한다.
+            return inspectionService.createInspection(request, itemId);
+        } catch (RuntimeException exception) {
+            // DB 저장 중 예외가 발생하면 업로드된 임시 파일도 함께 정리한다.
+            fileService.deleteFiles(uploadedFileKeys);
+            throw exception;
+        }
+    }
+
+    /**
+     * 등록 요청에 포함된 임시 업로드 파일 key 목록을 추출한다.
+     * 실패 시 cleanup 대상으로 사용한다.
+     */
+    private List<String> extractUploadedFileKeys(CreateInspectionRequest request) {
+        if (request == null || request.getItem() == null || request.getItem().getImages() == null) {
+            return List.of();
+        }
+
+        return request.getItem().getImages().stream()
+                .filter(image -> image != null && image.getFileKey() != null && !image.getFileKey().isBlank())
+                .map(CreateInspectionRequest.Image::getFileKey)
+                .toList();
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionService.java
@@ -1,0 +1,13 @@
+package com.biddingmate.biddinggo.inspection.service;
+
+import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+
+/**
+ * inspection 테이블 저장 책임을 담당하는 서비스.
+ */
+public interface InspectionService {
+    /**
+     * 이미 생성된 itemId를 기준으로 inspection 데이터를 저장한다.
+     */
+    Long createInspection(CreateInspectionRequest request, Long itemId);
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionServiceImpl.java
@@ -1,0 +1,54 @@
+package com.biddingmate.biddinggo.inspection.service;
+
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
+import com.biddingmate.biddinggo.inspection.model.Inspection;
+import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+/**
+ * inspection 엔티티 생성만 담당하는 서비스 구현체.
+ * 트랜잭션은 상위 애플리케이션 서비스에서 시작된 흐름에 참여한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class InspectionServiceImpl implements InspectionService {
+    private final InspectionMapper inspectionMapper;
+
+    @Override
+    /**
+     * 검수 대상 itemId를 기준으로 inspection 레코드를 생성한다.
+     * 최초 등록 상태는 항상 PENDING으로 시작한다.
+     */
+    public Long createInspection(CreateInspectionRequest request, Long itemId) {
+        if (itemId == null) {
+            throw new CustomException(ErrorType.INVALID_INSPECTION_CREATE_REQUEST);
+        }
+
+        // 검수 발송 정보는 선택 입력이므로 null 여부를 분기해서 사용한다.
+        CreateInspectionRequest.Inspection inspectionRequest = request.getInspection();
+
+        // inspection 테이블 저장용 모델로 변환한다.
+        Inspection inspection = Inspection.builder()
+                .itemId(itemId)
+                .status(InspectionStatus.PENDING)
+                .carrier(inspectionRequest != null ? inspectionRequest.getCarrier() : null)
+                .trackingNumber(inspectionRequest != null ? inspectionRequest.getTrackingNumber() : null)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // inspection 저장 후 생성된 PK를 모델에 주입받는다.
+        int inspectionInsertCount = inspectionMapper.insert(inspection);
+
+        if (inspectionInsertCount != 1 || inspection.getId() == null) {
+            throw new CustomException(ErrorType.INSPECTION_SAVE_FAILED);
+        }
+
+        return inspection.getId();
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/item/dto/AuctionItemCreateSource.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/dto/AuctionItemCreateSource.java
@@ -1,0 +1,15 @@
+package com.biddingmate.biddinggo.item.dto;
+
+public interface AuctionItemCreateSource {
+    Long getSellerId();
+
+    Long getCategoryId();
+
+    String getBrand();
+
+    String getName();
+
+    String getQuality();
+
+    String getDescription();
+}

--- a/src/main/java/com/biddingmate/biddinggo/item/dto/ItemImageCreateSource.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/dto/ItemImageCreateSource.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.item.dto;
+
+public interface ItemImageCreateSource {
+    String getFileKey();
+
+    Integer getDisplayOrder();
+}

--- a/src/main/java/com/biddingmate/biddinggo/item/model/AuctionItem.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/model/AuctionItem.java
@@ -22,7 +22,7 @@ public class AuctionItem {
     private String quality;
     private String description;
     private AuctionItemStatus status;
-    private InspectionStatus inspectionStatus;
+    private ItemInspectionStatus inspectionStatus;
     private LocalDateTime returnedAt;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/model/ItemInspectionStatus.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/model/ItemInspectionStatus.java
@@ -1,6 +1,6 @@
 package com.biddingmate.biddinggo.item.model;
 
-public enum InspectionStatus {
+public enum ItemInspectionStatus {
     NONE,
     PENDING,
     PASSED,

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemService.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemService.java
@@ -7,12 +7,19 @@ import com.biddingmate.biddinggo.item.dto.AuctionItemCreateSource;
  */
 public interface AuctionItemService {
     /**
-     * 경매 등록 요청에서 상품 정보만 분리하여 auction_item을 생성한다.
+     * 경매 등록용 auction_item을 생성한다.
+     *
+     * <p>{@code auction_item.inspection_status}는 이 단계에서 명시하지 않고,
+     * DB 기본값({@code NONE})을 사용한다.</p>
      */
     Long createAuctionItem(AuctionItemCreateSource item);
 
     /**
-     * 검수 등록용 상품을 생성한다.
+     * 검수 등록용 auction_item을 생성한다.
+     *
+     * <p>검수 등록은 일반 경매 등록과 달리,
+     * {@code auction_item.status = PENDING},
+     * {@code auction_item.inspection_status = PENDING}을 명시 저장한다.</p>
      */
     Long createInspectionItem(AuctionItemCreateSource item);
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemService.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemService.java
@@ -1,6 +1,6 @@
 package com.biddingmate.biddinggo.item.service;
 
-import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
+import com.biddingmate.biddinggo.item.dto.AuctionItemCreateSource;
 
 /**
  * auction_item 테이블 저장 책임을 담당하는 서비스.
@@ -9,5 +9,10 @@ public interface AuctionItemService {
     /**
      * 경매 등록 요청에서 상품 정보만 분리하여 auction_item을 생성한다.
      */
-    Long createAuctionItem(CreateAuctionRequest request);
+    Long createAuctionItem(AuctionItemCreateSource item);
+
+    /**
+     * 검수 등록용 상품을 생성한다.
+     */
+    Long createInspectionItem(AuctionItemCreateSource item);
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 /**
  * auction_item 엔티티 생성만 담당하는 서비스 구현체.
  * 경매 등록 시 선택한 카테고리가 실제 최하위 카테고리인지 함께 검증한다.
+ * {@code auction_item.status}, {@code auction_item.inspection_status} 결정도 이 클래스가 담당한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -25,15 +26,30 @@ public class AuctionItemServiceImpl implements AuctionItemService {
     private final CategoryMapper categoryMapper;
 
     @Override
+    /**
+     * 경매 등록용 item 생성.
+     * status/inspectionStatus를 null로 넘겨 DB 기본값을 사용한다.
+     */
     public Long createAuctionItem(AuctionItemCreateSource item) {
         return createItem(item, null, null);
     }
 
     @Override
+    /**
+     * 검수 등록용 item 생성.
+     * 검수 대기 상품이므로 status와 inspectionStatus를 모두 PENDING으로 명시한다.
+     */
     public Long createInspectionItem(AuctionItemCreateSource item) {
         return createItem(item, AuctionItemStatus.PENDING, InspectionStatus.PENDING);
     }
 
+    /**
+     * 공통 auction_item 저장 로직.
+     *
+     * <p>이 메서드는 상품 기본 정보 저장뿐 아니라
+     * {@code auction_item.status}, {@code auction_item.inspection_status} 초기값도 함께 결정한다.</p>
+     * <p>두 값이 null이면 mapper에서 해당 컬럼을 INSERT에서 제외하고 DB 기본값을 사용한다.</p>
+     */
     private Long createItem(AuctionItemCreateSource item, AuctionItemStatus status, InspectionStatus inspectionStatus) {
         // 등록 요청에서 선택한 categoryId가 실제 존재하는지 확인한다.
         Category category = categoryMapper.findById(item.getCategoryId());
@@ -48,6 +64,7 @@ public class AuctionItemServiceImpl implements AuctionItemService {
         }
 
         // request를 DB 저장용 auction_item 모델로 변환한다.
+        // inspection_status는 AuctionService/InspectionService가 아니라 여기서 세팅된다.
         AuctionItem auctionItem = AuctionItem.builder()
                 .sellerId(item.getSellerId())
                 .categoryId(item.getCategoryId())

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
@@ -8,7 +8,7 @@ import com.biddingmate.biddinggo.item.mapper.CategoryMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.item.model.Category;
-import com.biddingmate.biddinggo.item.model.InspectionStatus;
+import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +40,7 @@ public class AuctionItemServiceImpl implements AuctionItemService {
      * 검수 대기 상품이므로 status와 inspectionStatus를 모두 PENDING으로 명시한다.
      */
     public Long createInspectionItem(AuctionItemCreateSource item) {
-        return createItem(item, AuctionItemStatus.PENDING, InspectionStatus.PENDING);
+        return createItem(item, AuctionItemStatus.PENDING, ItemInspectionStatus.PENDING);
     }
 
     /**
@@ -50,7 +50,7 @@ public class AuctionItemServiceImpl implements AuctionItemService {
      * {@code auction_item.status}, {@code auction_item.inspection_status} 초기값도 함께 결정한다.</p>
      * <p>두 값이 null이면 mapper에서 해당 컬럼을 INSERT에서 제외하고 DB 기본값을 사용한다.</p>
      */
-    private Long createItem(AuctionItemCreateSource item, AuctionItemStatus status, InspectionStatus inspectionStatus) {
+    private Long createItem(AuctionItemCreateSource item, AuctionItemStatus status, ItemInspectionStatus inspectionStatus) {
         // 등록 요청에서 선택한 categoryId가 실제 존재하는지 확인한다.
         Category category = categoryMapper.findById(item.getCategoryId());
 

--- a/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/AuctionItemServiceImpl.java
@@ -1,12 +1,14 @@
 package com.biddingmate.biddinggo.item.service;
 
-import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.item.dto.AuctionItemCreateSource;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.mapper.CategoryMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
+import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.item.model.Category;
+import com.biddingmate.biddinggo.item.model.InspectionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,9 +25,18 @@ public class AuctionItemServiceImpl implements AuctionItemService {
     private final CategoryMapper categoryMapper;
 
     @Override
-    public Long createAuctionItem(CreateAuctionRequest request) {
+    public Long createAuctionItem(AuctionItemCreateSource item) {
+        return createItem(item, null, null);
+    }
+
+    @Override
+    public Long createInspectionItem(AuctionItemCreateSource item) {
+        return createItem(item, AuctionItemStatus.PENDING, InspectionStatus.PENDING);
+    }
+
+    private Long createItem(AuctionItemCreateSource item, AuctionItemStatus status, InspectionStatus inspectionStatus) {
         // 등록 요청에서 선택한 categoryId가 실제 존재하는지 확인한다.
-        Category category = categoryMapper.findById(request.getItem().getCategoryId());
+        Category category = categoryMapper.findById(item.getCategoryId());
 
         if (category == null) {
             throw new CustomException(ErrorType.CATEGORY_NOT_FOUND);
@@ -38,12 +49,14 @@ public class AuctionItemServiceImpl implements AuctionItemService {
 
         // request를 DB 저장용 auction_item 모델로 변환한다.
         AuctionItem auctionItem = AuctionItem.builder()
-                .sellerId(request.getItem().getSellerId())
-                .categoryId(request.getItem().getCategoryId())
-                .brand(request.getItem().getBrand())
-                .name(request.getItem().getName())
-                .quality(request.getItem().getQuality())
-                .description(request.getItem().getDescription())
+                .sellerId(item.getSellerId())
+                .categoryId(item.getCategoryId())
+                .brand(item.getBrand())
+                .name(item.getName())
+                .quality(item.getQuality())
+                .description(item.getDescription())
+                .status(status)
+                .inspectionStatus(inspectionStatus)
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/src/main/java/com/biddingmate/biddinggo/item/service/ItemImageService.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/ItemImageService.java
@@ -1,6 +1,6 @@
 package com.biddingmate.biddinggo.item.service;
 
-import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
+import com.biddingmate.biddinggo.item.dto.ItemImageCreateSource;
 
 import java.util.List;
 
@@ -11,5 +11,5 @@ public interface ItemImageService {
     /**
      * 업로드된 이미지 메타데이터를 item_image 테이블에 저장한다.
      */
-    void createItemImages(Long itemId, List<CreateAuctionRequest.Image> images);
+    void createItemImages(Long itemId, List<? extends ItemImageCreateSource> images);
 }

--- a/src/main/java/com/biddingmate/biddinggo/item/service/ItemImageServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/service/ItemImageServiceImpl.java
@@ -1,10 +1,10 @@
 package com.biddingmate.biddinggo.item.service;
 
-import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.file.model.FileMetadata;
 import com.biddingmate.biddinggo.file.service.FileService;
+import com.biddingmate.biddinggo.item.dto.ItemImageCreateSource;
 import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
 import com.biddingmate.biddinggo.item.model.ItemImage;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class ItemImageServiceImpl implements ItemImageService {
      * displayOrder 중복 여부를 먼저 확인하고,
      * 각 파일의 실제 R2 메타데이터를 조회해 DB에 저장한다.
      */
-    public void createItemImages(Long itemId, List<CreateAuctionRequest.Image> images) {
+    public void createItemImages(Long itemId, List<? extends ItemImageCreateSource> images) {
         if (images == null || images.isEmpty()) {
             return;
         }
@@ -42,7 +42,7 @@ public class ItemImageServiceImpl implements ItemImageService {
 
         validateDisplayOrders(images);
 
-        for (CreateAuctionRequest.Image image : images) {
+        for (ItemImageCreateSource image : images) {
             if (!fileService.isManagedFileKey(image.getFileKey())) {
                 throw new CustomException(ErrorType.INVALID_AUCTION_CREATE_REQUEST);
             }
@@ -69,10 +69,10 @@ public class ItemImageServiceImpl implements ItemImageService {
     /**
      * 같은 item 안에서 이미지 노출 순서가 중복되지 않도록 검증한다.
      */
-    private void validateDisplayOrders(List<CreateAuctionRequest.Image> images) {
+    private void validateDisplayOrders(List<? extends ItemImageCreateSource> images) {
         Set<Integer> displayOrders = new HashSet<>();
 
-        for (CreateAuctionRequest.Image image : images) {
+        for (ItemImageCreateSource image : images) {
             if (!displayOrders.add(image.getDisplayOrder())) {
                 throw new CustomException(ErrorType.DUPLICATE_ITEM_IMAGE_DISPLAY_ORDER);
             }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,3 +5,6 @@ spring:
     import: optional:file:.env[.properties]
   profiles:
     active: local
+
+server:
+  port: 8088

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.biddingmate.biddinggo.inspection.mapper.InspectionMapper">
+
+    <insert id="insert" parameterType="Inspection" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO inspection
+        <trim prefix="(" suffix=")" suffixOverrides=",">
+            item_id,
+            <if test="receivedAt != null">received_at,</if>
+            <if test="status != null">status,</if>
+            <if test="completedAt != null">completed_at,</if>
+            <if test="failureReason != null">failure_reason,</if>
+            <if test="carrier != null">carrier,</if>
+            <if test="trackingNumber != null">tracking_number,</if>
+            created_at
+        </trim>
+        <trim prefix="VALUES (" suffix=")" suffixOverrides=",">
+            #{itemId},
+            <if test="receivedAt != null">#{receivedAt},</if>
+            <if test="status != null">#{status},</if>
+            <if test="completedAt != null">#{completedAt},</if>
+            <if test="failureReason != null">#{failureReason},</if>
+            <if test="carrier != null">#{carrier},</if>
+            <if test="trackingNumber != null">#{trackingNumber},</if>
+            #{createdAt}
+        </trim>
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## 📌 PR 유형

  - [x] Feature (새로운 기능 추가)
  - [ ] Fix (버그 수정)
  - [x] Refactor (코드 리팩토링)
  - [ ] Chore (유지보수, 의존성 업데이트 등)
  - [ ] Docs (문서 작성/수정)

  ———

  ## 📝 작업 내용

  - 상품 검수 등록 기능을 추가했습니다
  - 검수 등록 전체 흐름을 담당하는 InspectionApplicationService와 InspectionService를 추가했습니다
  - 검수 등록 시 auction_item -> item_image -> inspection 순서로 저장되도록 구현하고, 실패 시 업로드 파일 cleanup이 동작하도록 구성했습니다
  - 기존 상품/이미지 저장 로직이 검수 등록에도 재사용될 수 있도록 공통 인터페이스 기반으로 리팩토링했습니다
  - 검수 등록 API POST /api/v1/inspections를 추가했습니다
  - 검수 등록 관련 예외 코드 INVALID_INSPECTION_CREATE_REQUEST, INSPECTION_SAVE_FAILED를 추가했습니다
  - Spring Security 허용 경로에 /api/v1/inspections/**를 추가했습니다
  - MyBatis type alias 충돌을 피하기 위해 아이템 쪽 검수 상태 enum 이름을 ItemInspectionStatus로 정리했습니다

  ———

  ## 📎 관련 이슈

  - closes #30 