### PR TITLE
feat: 검수 배송 정보 등록 기능 추가

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -45,6 +45,10 @@ public enum ErrorType {
     // 검수
     INVALID_INSPECTION_CREATE_REQUEST("inspection-001", "검수 등록 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INSPECTION_SAVE_FAILED("inspection-002", "검수 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INSPECTION_NOT_FOUND("inspection-003", "검수 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_INSPECTION_STATUS("inspection-004", "현재 검수 상태에서는 배송 정보를 등록할 수 없습니다.", HttpStatus.CONFLICT),
+    INSPECTION_SHIPPING_INFO_ALREADY_EXISTS("inspection-005", "이미 배송 정보가 등록된 검수입니다.", HttpStatus.CONFLICT),
+    INSPECTION_SHIPPING_UPDATE_FAILED("inspection-006", "검수 배송 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
@@ -3,13 +3,17 @@ package com.biddingmate.biddinggo.inspection.controller;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionResponse;
+import com.biddingmate.biddinggo.inspection.dto.UpdateInspectionShippingRequest;
 import com.biddingmate.biddinggo.inspection.service.InspectionApplicationService;
+import com.biddingmate.biddinggo.inspection.service.InspectionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Inspection", description = "상품 검수 등록 API")
 public class InspectionController {
     private final InspectionApplicationService inspectionApplicationService;
+    private final InspectionService inspectionService;
 
     @PostMapping("")
     @Operation(summary = "상품 검수 등록", description = "검수 대상 상품, 이미지, 검수 정보를 함께 등록합니다.")
@@ -34,5 +39,20 @@ public class InspectionController {
                 .build();
 
         return ApiResponse.of(HttpStatus.OK, null, "상품 검수 등록 완료", result);
+    }
+
+    @PatchMapping("/{inspectionId}/shipping")
+    @Operation(summary = "검수 배송 정보 등록", description = "검수에 택배사와 송장 번호를 등록합니다.")
+    public ResponseEntity<ApiResponse<CreateInspectionResponse>> updateShippingInfo(
+            @PathVariable Long inspectionId,
+            @Valid @RequestBody UpdateInspectionShippingRequest request) {
+
+        inspectionService.updateShippingInfo(inspectionId, request);
+
+        CreateInspectionResponse result = CreateInspectionResponse.builder()
+                .inspectionId(inspectionId)
+                .build();
+
+        return ApiResponse.of(HttpStatus.OK, null, "검수 배송 정보 등록 완료", result);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/UpdateInspectionShippingRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/UpdateInspectionShippingRequest.java
@@ -1,0 +1,28 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "검수 배송 정보 등록 요청 DTO")
+public class UpdateInspectionShippingRequest {
+    @Schema(description = "택배사", example = "CJ대한통운")
+    @NotBlank(message = "택배사는 필수입니다.")
+    @Size(max = 20, message = "택배사는 20자 이하여야 합니다.")
+    private String carrier;
+
+    @Schema(description = "송장 번호", example = "1234567890")
+    @NotBlank(message = "송장 번호는 필수입니다.")
+    @Size(max = 255, message = "송장 번호는 255자 이하여야 합니다.")
+    private String trackingNumber;
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
@@ -2,8 +2,16 @@ package com.biddingmate.biddinggo.inspection.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import com.biddingmate.biddinggo.inspection.model.Inspection;
+import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface InspectionMapper extends IMybatisCRUD<Inspection> {
+    int updateShippingInfo(
+            @Param("inspectionId") Long inspectionId,
+            @Param("carrier") String carrier,
+            @Param("trackingNumber") String trackingNumber,
+            @Param("currentStatus") InspectionStatus currentStatus
+    );
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionService.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.inspection.service;
 
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+import com.biddingmate.biddinggo.inspection.dto.UpdateInspectionShippingRequest;
 
 /**
  * inspection 테이블 저장 책임을 담당하는 서비스.
@@ -10,4 +11,9 @@ public interface InspectionService {
      * 이미 생성된 itemId를 기준으로 inspection 데이터를 저장한다.
      */
     Long createInspection(CreateInspectionRequest request, Long itemId);
+
+    /**
+     * 검수 배송 정보(택배사, 송장 번호)를 등록한다.
+     */
+    void updateShippingInfo(Long inspectionId, UpdateInspectionShippingRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionServiceImpl.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.inspection.service;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
+import com.biddingmate.biddinggo.inspection.dto.UpdateInspectionShippingRequest;
 import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
 import com.biddingmate.biddinggo.inspection.model.Inspection;
 import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
@@ -50,5 +51,37 @@ public class InspectionServiceImpl implements InspectionService {
         }
 
         return inspection.getId();
+    }
+
+    @Override
+    /**
+     * 검수 배송 정보(택배사, 송장 번호)를 사후 등록한다.
+     * 배송 정보는 PENDING 상태의 검수에만 최초 1회 등록 가능하다.
+     */
+    public void updateShippingInfo(Long inspectionId, UpdateInspectionShippingRequest request) {
+        Inspection inspection = inspectionMapper.findById(inspectionId);
+
+        if (inspection == null) {
+            throw new CustomException(ErrorType.INSPECTION_NOT_FOUND);
+        }
+
+        if (inspection.getStatus() != InspectionStatus.PENDING) {
+            throw new CustomException(ErrorType.INVALID_INSPECTION_STATUS);
+        }
+
+        if (inspection.getCarrier() != null || inspection.getTrackingNumber() != null) {
+            throw new CustomException(ErrorType.INSPECTION_SHIPPING_INFO_ALREADY_EXISTS);
+        }
+
+        int updatedCount = inspectionMapper.updateShippingInfo(
+                inspectionId,
+                request.getCarrier(),
+                request.getTrackingNumber(),
+                InspectionStatus.PENDING
+        );
+
+        if (updatedCount != 1) {
+            throw new CustomException(ErrorType.INSPECTION_SHIPPING_UPDATE_FAILED);
+        }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,3 @@
-server:
-  port: 8088
 spring:
   application:
     name: bidding-go

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,5 +8,3 @@ spring:
   profiles:
     active: local
 
-server:
-  port: 8088

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -8,6 +8,13 @@
         <result property="itemId" column="item_id"/>
         <result property="receivedAt" column="received_at"/>
         <result property="status" column="status"/>
+        <result property="completedAt" column="completed_at"/>
+        <result property="failureReason" column="failure_reason"/>
+        <result property="carrier" column="carrier"/>
+        <result property="trackingNumber" column="tracking_number"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
     <resultMap id="inspectionDetailResultMap" type="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse">
         <id property="inspectionId" column="inspection_id"/>
         <result property="status" column="inspection_status"/>
@@ -16,7 +23,20 @@
         <result property="failureReason" column="failure_reason"/>
         <result property="carrier" column="carrier"/>
         <result property="trackingNumber" column="tracking_number"/>
-        <result property="createdAt" column="created_at"/>
+        <result property="createdAt" column="inspection_created_at"/>
+        <association property="item" javaType="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Item">
+            <id property="itemId" column="item_id"/>
+            <result property="sellerId" column="seller_id"/>
+            <result property="brand" column="brand"/>
+            <result property="name" column="name"/>
+            <result property="quality" column="quality"/>
+            <result property="description" column="description"/>
+            <association property="category" javaType="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Category">
+                <id property="id" column="category_id"/>
+                <result property="name" column="category_name"/>
+                <result property="level" column="category_level"/>
+            </association>
+        </association>
     </resultMap>
 
     <select id="findById" parameterType="long" resultMap="inspectionResultMap">
@@ -40,27 +60,11 @@
             tracking_number = #{trackingNumber}
         WHERE id = #{inspectionId}
         <if test="currentStatus != null">
-          AND status = #{currentStatus}
+            AND status = #{currentStatus}
         </if>
-          AND carrier IS NULL
-          AND tracking_number IS NULL
+        AND carrier IS NULL
+        AND tracking_number IS NULL
     </update>
-
-        <result property="createdAt" column="inspection_created_at"/>
-        <association property="item" javaType="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Item">
-            <id property="itemId" column="item_id"/>
-            <result property="sellerId" column="seller_id"/>
-            <result property="brand" column="brand"/>
-            <result property="name" column="name"/>
-            <result property="quality" column="quality"/>
-            <result property="description" column="description"/>
-            <association property="category" javaType="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Category">
-                <id property="id" column="category_id"/>
-                <result property="name" column="category_name"/>
-                <result property="level" column="category_level"/>
-            </association>
-        </association>
-    </resultMap>
 
     <select id="findDetailById" parameterType="long" resultMap="inspectionDetailResultMap">
         SELECT

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -3,6 +3,45 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.biddingmate.biddinggo.inspection.mapper.InspectionMapper">
 
+    <resultMap id="inspectionResultMap" type="Inspection">
+        <id property="id" column="id"/>
+        <result property="itemId" column="item_id"/>
+        <result property="receivedAt" column="received_at"/>
+        <result property="status" column="status"/>
+        <result property="completedAt" column="completed_at"/>
+        <result property="failureReason" column="failure_reason"/>
+        <result property="carrier" column="carrier"/>
+        <result property="trackingNumber" column="tracking_number"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <select id="findById" parameterType="long" resultMap="inspectionResultMap">
+        SELECT
+            id,
+            item_id,
+            received_at,
+            status,
+            completed_at,
+            failure_reason,
+            carrier,
+            tracking_number,
+            created_at
+        FROM inspection
+        WHERE id = #{id}
+    </select>
+
+    <update id="updateShippingInfo">
+        UPDATE inspection
+        SET carrier = #{carrier},
+            tracking_number = #{trackingNumber}
+        WHERE id = #{inspectionId}
+        <if test="currentStatus != null">
+          AND status = #{currentStatus}
+        </if>
+          AND carrier IS NULL
+          AND tracking_number IS NULL
+    </update>
+
     <insert id="insert" parameterType="Inspection" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO inspection
         <trim prefix="(" suffix=")" suffixOverrides=",">


### PR DESCRIPTION
## 📌 PR 유형

- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

———

## 📝 작업 내용

- 검수 배송 정보 등록 기능을 추가했습니다
- PATCH /api/v1/inspections/{inspectionId}/shipping 엔드포인트를 추가했습니다
- 배송 정보 등록 전용 요청 DTO를 추가했습니다
- inspection 조회 및 배송 정보 업데이트 매퍼를 추가했습니다
- 검수 존재 여부, PENDING 상태 여부, 배송 정보 중복 등록 여부를 검증하도록 서비스 로직을 추가했습니다
- 배송 정보 등록 관련 예외 코드를 추가했습니다

———

## 📎 관련 이슈

- closes #34 