### PR TITLE
feat: 검수 아이템 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -45,6 +45,10 @@ public enum ErrorType {
     // 검수
     INVALID_INSPECTION_CREATE_REQUEST("inspection-001", "검수 등록 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INSPECTION_SAVE_FAILED("inspection-002", "검수 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INSPECTION_NOT_FOUND("inspection-003", "검수 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_INSPECTION_STATUS("inspection-004", "현재 검수 상태에서는 처리할 수 없습니다.", HttpStatus.CONFLICT),
+    INSPECTION_SHIPPING_INFO_ALREADY_EXISTS("inspection-005", "이미 배송 정보가 등록된 검수입니다.", HttpStatus.CONFLICT),
+    INSPECTION_SHIPPING_UPDATE_FAILED("inspection-006", "검수 배송 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
@@ -3,13 +3,17 @@ package com.biddingmate.biddinggo.inspection.controller;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.inspection.service.InspectionApplicationService;
+import com.biddingmate.biddinggo.inspection.service.InspectionQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +25,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Inspection", description = "상품 검수 등록 API")
 public class InspectionController {
     private final InspectionApplicationService inspectionApplicationService;
+    private final InspectionQueryService inspectionQueryService;
+
+    @GetMapping("/{inspectionId}")
+    @Operation(summary = "검수 아이템 상세 조회", description = "검수 정보, 상품 정보, 카테고리, 이미지 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<InspectionDetailResponse>> getInspectionDetail(
+            @PathVariable Long inspectionId) {
+
+        InspectionDetailResponse result = inspectionQueryService.getInspectionDetail(inspectionId);
+
+        return ApiResponse.of(HttpStatus.OK, null, "검수 아이템 상세 조회 완료", result);
+    }
 
     @PostMapping("")
     @Operation(summary = "상품 검수 등록", description = "검수 대상 상품, 이미지, 검수 정보를 함께 등록합니다.")

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionDetailResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionDetailResponse.java
@@ -1,0 +1,110 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "검수 아이템 상세 조회 응답 DTO")
+public class InspectionDetailResponse {
+    @Schema(description = "검수 ID", example = "12")
+    private Long inspectionId;
+
+    @Schema(description = "검수 상태", example = "PENDING")
+    private InspectionStatus status;
+
+    @Schema(description = "검수 수령 일시", nullable = true)
+    private LocalDateTime receivedAt;
+
+    @Schema(description = "검수 완료 일시", nullable = true)
+    private LocalDateTime completedAt;
+
+    @Schema(description = "검수 실패 사유", nullable = true)
+    private String failureReason;
+
+    @Schema(description = "택배사", nullable = true)
+    private String carrier;
+
+    @Schema(description = "송장 번호", nullable = true)
+    private String trackingNumber;
+
+    @Schema(description = "검수 생성일시")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "상품 정보")
+    private Item item;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "검수 대상 상품 정보")
+    public static class Item {
+        @Schema(description = "상품 ID", example = "10")
+        private Long itemId;
+
+        @Schema(description = "판매자 ID", example = "1")
+        private Long sellerId;
+
+        @Schema(description = "브랜드명", example = "Nike")
+        private String brand;
+
+        @Schema(description = "상품명", example = "Air Jordan 1 High")
+        private String name;
+
+        @Schema(description = "상품 상태", example = "최상")
+        private String quality;
+
+        @Schema(description = "상품 설명", example = "실착 2회, 박스 포함")
+        private String description;
+
+        @Schema(description = "카테고리 정보")
+        private Category category;
+
+        @Schema(description = "상품 이미지 목록")
+        private List<Image> images;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "카테고리 정보")
+    public static class Category {
+        @Schema(description = "카테고리 ID", example = "100")
+        private Long id;
+
+        @Schema(description = "카테고리명", example = "하이탑")
+        private String name;
+
+        @Schema(description = "카테고리 level", example = "3")
+        private Integer level;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "상품 이미지 정보")
+    public static class Image {
+        @Schema(description = "이미지 URL")
+        private String url;
+
+        @Schema(description = "노출 순서", example = "1")
+        private Integer displayOrder;
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
@@ -1,9 +1,11 @@
 package com.biddingmate.biddinggo.inspection.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.inspection.model.Inspection;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface InspectionMapper extends IMybatisCRUD<Inspection> {
+    InspectionDetailResponse findDetailById(Long inspectionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
@@ -1,0 +1,14 @@
+package com.biddingmate.biddinggo.inspection.service;
+
+import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
+
+/**
+ * 검수 조회 전용 서비스.
+ * 등록/수정 로직과 분리하여 읽기 책임만 담당한다.
+ */
+public interface InspectionQueryService {
+    /**
+     * 검수 ID를 기준으로 상세 정보를 조회한다.
+     */
+    InspectionDetailResponse getInspectionDetail(Long inspectionId);
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
@@ -1,0 +1,48 @@
+package com.biddingmate.biddinggo.inspection.service;
+
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
+import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
+import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 검수 상세 조회 구현체.
+ * 본문 정보와 이미지 목록을 분리 조회한 뒤 하나의 응답 DTO로 조합한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class InspectionQueryServiceImpl implements InspectionQueryService {
+    private final InspectionMapper inspectionMapper;
+    private final ItemImageMapper itemImageMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    /**
+     * 검수 상세 조회 메인 로직.
+     * 1) 검수/상품/카테고리 본문 조회
+     * 2) item_image 목록 조회
+     * 3) 이미지 목록을 응답 객체에 조합
+     */
+    public InspectionDetailResponse getInspectionDetail(Long inspectionId) {
+        if (inspectionId == null || inspectionId <= 0) {
+            throw new CustomException(ErrorType.BAD_REQUEST);
+        }
+
+        InspectionDetailResponse detail = inspectionMapper.findDetailById(inspectionId);
+
+        if (detail == null) {
+            throw new CustomException(ErrorType.INSPECTION_NOT_FOUND);
+        }
+
+        List<InspectionDetailResponse.Image> images = itemImageMapper.findInspectionDetailImagesByItemId(detail.getItem().getItemId());
+        detail.getItem().setImages(images);
+
+        return detail;
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/item/mapper/ItemImageMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/item/mapper/ItemImageMapper.java
@@ -2,6 +2,7 @@ package com.biddingmate.biddinggo.item.mapper;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.item.model.ItemImage;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -10,4 +11,5 @@ import java.util.List;
 @Mapper
 public interface ItemImageMapper extends IMybatisCRUD<ItemImage> {
     List<AuctionDetailResponse.Image> findDetailImagesByItemId(Long itemId);
+    List<InspectionDetailResponse.Image> findInspectionDetailImagesByItemId(Long itemId);
 }

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -3,6 +3,55 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.biddingmate.biddinggo.inspection.mapper.InspectionMapper">
 
+    <resultMap id="inspectionDetailResultMap" type="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse">
+        <id property="inspectionId" column="inspection_id"/>
+        <result property="status" column="inspection_status"/>
+        <result property="receivedAt" column="received_at"/>
+        <result property="completedAt" column="completed_at"/>
+        <result property="failureReason" column="failure_reason"/>
+        <result property="carrier" column="carrier"/>
+        <result property="trackingNumber" column="tracking_number"/>
+        <result property="createdAt" column="inspection_created_at"/>
+        <association property="item" javaType="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Item">
+            <id property="itemId" column="item_id"/>
+            <result property="sellerId" column="seller_id"/>
+            <result property="brand" column="brand"/>
+            <result property="name" column="name"/>
+            <result property="quality" column="quality"/>
+            <result property="description" column="description"/>
+            <association property="category" javaType="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Category">
+                <id property="id" column="category_id"/>
+                <result property="name" column="category_name"/>
+                <result property="level" column="category_level"/>
+            </association>
+        </association>
+    </resultMap>
+
+    <select id="findDetailById" parameterType="long" resultMap="inspectionDetailResultMap">
+        SELECT
+            i.id AS inspection_id,
+            i.status AS inspection_status,
+            i.received_at,
+            i.completed_at,
+            i.failure_reason,
+            i.carrier,
+            i.tracking_number,
+            i.created_at AS inspection_created_at,
+            ai.id AS item_id,
+            ai.seller_id,
+            ai.brand,
+            ai.name,
+            ai.quality,
+            ai.description,
+            c.id AS category_id,
+            c.name AS category_name,
+            c.level AS category_level
+        FROM inspection i
+        INNER JOIN auction_item ai ON i.item_id = ai.id
+        INNER JOIN category c ON ai.category_id = c.id
+        WHERE i.id = #{inspectionId}
+    </select>
+
     <insert id="insert" parameterType="Inspection" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO inspection
         <trim prefix="(" suffix=")" suffixOverrides=",">

--- a/src/main/resources/mapper/item/item-image-mapper.xml
+++ b/src/main/resources/mapper/item/item-image-mapper.xml
@@ -8,6 +8,11 @@
         <result property="displayOrder" column="display_order"/>
     </resultMap>
 
+    <resultMap id="inspectionDetailImageResultMap" type="com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse$Image">
+        <result property="url" column="url"/>
+        <result property="displayOrder" column="display_order"/>
+    </resultMap>
+
     <insert id="insert" parameterType="ItemImage" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO item_image(
             item_id,
@@ -27,6 +32,15 @@
     </insert>
 
     <select id="findDetailImagesByItemId" parameterType="long" resultMap="auctionDetailImageResultMap">
+        SELECT
+            url,
+            display_order
+        FROM item_image
+        WHERE item_id = #{itemId}
+        ORDER BY display_order ASC
+    </select>
+
+    <select id="findInspectionDetailImagesByItemId" parameterType="long" resultMap="inspectionDetailImageResultMap">
         SELECT
             url,
             display_order


### PR DESCRIPTION
## 📌 PR 유형

- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

———

## 📝 작업 내용

- 검수 아이템 상세 조회 기능을 추가했습니다
- GET /api/v1/inspections/{inspectionId} 엔드포인트를 추가했습니다
- 검수 상세 조회 응답 DTO를 추가했습니다
- inspection, auction_item, category를 조인하는 상세 조회 쿼리를 추가했습니다
- 이미지 목록은 별도 조회 후 서비스에서 조합하도록 구현했습니다
- 존재하지 않는 검수 ID 조회 시 예외 처리하도록 구성했습니다

———

## 📎 관련 이슈

- closes #37 