### PR TITLE
feat: 유저 마이페이지 홈 조회 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -62,7 +62,10 @@ public enum ErrorType {
     INVALID_UPLOADED_FILE_METADATA("file-006", "업로드된 파일 메타데이터가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 1대1 문의
-    ADMIN_INQUIRY_CREATED_FAIL("admin-inquiry-001", "관리자 1대1 문의 생성 실패" , HttpStatus.INTERNAL_SERVER_ERROR);
+    ADMIN_INQUIRY_CREATED_FAIL("admin-inquiry-001", "관리자 1대1 문의 생성 실패" , HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 회원 정보
+    MEMBER_NOT_FOUND("member-001", "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
+++ b/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                                 "/api/v1/payments/**", "/api/v1/files/**",
                                 "/api/v1/auctions/**", "/api/v1/inspections/**",
                                 "/api/v1/admin-inquiries/**",
-                                "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                "/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/v1/users/my").permitAll()
                         .anyRequest().authenticated());
         return http.build();
     }

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.biddingmate.biddinggo.member.controller;
+
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.member.dto.MemberMyResponse;
+import com.biddingmate.biddinggo.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<MemberMyResponse>> getMyInfo(@RequestParam Long memberId) {
+        MemberMyResponse result = memberService.getMyInfo(memberId);
+        return ApiResponse.of(HttpStatus.OK, null, "회원 마이페이지 조회 성공", result);
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberMyResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberMyResponse.java
@@ -1,0 +1,18 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberMyResponse {
+    private Long totalPurchaseAmount;
+
+    private Long totalSalesAmount;
+
+    private Long point;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.member.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.member.dto.MemberMyResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -8,5 +9,8 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface MemberMapper extends IMybatisCRUD<Member> {
     void addPoint(@Param("id") Long id, @Param("amount") Long amount);
+
+    MemberMyResponse selectMyInfo(@Param("memberId") Long memberId);
+
 
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/model/Member.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/model/Member.java
@@ -1,4 +1,30 @@
 package com.biddingmate.biddinggo.member.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Member {
+    private Long id;
+    private String name;
+    private String nickname;
+    private String email;
+    private String imageUrl;
+    private Long point;
+    private String bankCode;
+    private String bankAccount;
+    private String grade;
+    private String role;
+    private String status;
+    private String lastChangeNick;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.member.service;
+
+import com.biddingmate.biddinggo.member.dto.MemberMyResponse;
+
+public interface MemberService {
+    MemberMyResponse getMyInfo(Long memberId);
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -1,0 +1,30 @@
+package com.biddingmate.biddinggo.member.service;
+
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.member.dto.MemberMyResponse;
+import com.biddingmate.biddinggo.member.mapper.MemberMapper;
+import com.biddingmate.biddinggo.member.model.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberMapper memberMapper;
+    @Override
+    public MemberMyResponse getMyInfo(Long memberId) {
+
+        // 회원 존재 여부 체크
+        Member member = memberMapper.findById(memberId);
+
+        // 회원 존재하지 않을 시, 예외처리
+        if (member == null) {
+            throw new CustomException(ErrorType.MEMBER_NOT_FOUND);
+        }
+
+        // 회원 존재 시, 조회
+        return memberMapper.selectMyInfo(memberId);
+    }
+}

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -12,7 +12,7 @@
             id = #{id};
     </update>
 
-    <select id="selectMyInfo" parameterType="long" resultType="com.biddingmate.biddinggo.member.dto.MemberMyResponse">
+    <select id="selectMyInfo" parameterType="long" resultType="MemberMyResponse">
         SELECT
             m.point AS point,
             COALESCE(p.total_purchase_amount, 0) AS totalPurchaseAmount,
@@ -37,7 +37,7 @@
         WHERE m.id = #{memberId}
     </select>
 
-    <select id="findById" parameterType="long" resultType="com.biddingmate.biddinggo.member.model.Member">
+    <select id="findById" parameterType="long" resultType="Member">
         SELECT
             id,
             name,

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -12,4 +12,47 @@
             id = #{id};
     </update>
 
+    <select id="selectMyInfo" parameterType="long" resultType="com.biddingmate.biddinggo.member.dto.MemberMyResponse">
+        SELECT
+            m.point AS point,
+            COALESCE(p.total_purchase_amount, 0) AS totalPurchaseAmount,
+            COALESCE(s.total_sales_amount, 0) AS totalSalesAmount
+        FROM member m
+
+        LEFT JOIN (
+            SELECT
+                winner_id,
+                SUM(winner_price) AS total_purchase_amount
+            FROM winner_deal
+            GROUP BY winner_id
+        ) p ON m.id = p.winner_id
+
+        LEFT JOIN (
+            SELECT
+                seller_id,
+                SUM(winner_price) AS total_sales_amount
+            FROM winner_deal
+            GROUP BY seller_id
+        ) s ON m.id = s.seller_id
+        WHERE m.id = #{memberId}
+    </select>
+
+    <select id="findById" parameterType="long" resultType="com.biddingmate.biddinggo.member.model.Member">
+        SELECT
+            id,
+            name,
+            nickname,
+            email,
+            image_url AS imageUrl,
+            point,
+            bank_code AS bankCode,
+            bank_account AS bankAccount,
+            grade,
+            role,
+            status,
+            last_change_nick AS lastChangeNick,
+            created_at AS createdAt
+        FROM member
+        WHERE id = #{id}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 유저 마이페이지 홈 조회 API 구현 (GET /api/v1/users/my)
- 회원의 총 구매 금액, 총 판매 금액, 포인트 조회 기능 구현
- winner_deal 테이블 기반 구매/판매 금액 집계 SQL 작성
- 거래 내역이 없는 경우 0으로 반환되도록 처리
- 회원 존재 여부 확인 후, 존재하지 않을 경우 예외 처리 (MEMBER_NOT_FOUND)
- DTO (MemberMyResponse) 기반 응답 구성

---

## 📎 관련 이슈

- close #45 
