### PR TITLE
feat: 경매 문의 등록 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/admininquiry/controller/AdminInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/admininquiry/controller/AdminInquiryController.java
@@ -6,7 +6,6 @@ import com.biddingmate.biddinggo.admininquiry.dto.AnswerAdminInquiryRequest;
 import com.biddingmate.biddinggo.admininquiry.dto.AnswerAdminInquiryResponse;
 import com.biddingmate.biddinggo.admininquiry.dto.CreateAdminInquiryRequest;
 import com.biddingmate.biddinggo.admininquiry.dto.CreateAdminInquiryResponse;
-import com.biddingmate.biddinggo.admininquiry.model.AdminInquiry;
 import com.biddingmate.biddinggo.admininquiry.service.AdminInquiryService;
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
@@ -15,7 +14,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -60,7 +58,7 @@ public class AdminInquiryController {
         AdminInquiryViewDetail result = adminInquiryService.findAdminInquiryDetail(inquiryId, isAdmin, memberId);
 
         return ApiResponse.of(HttpStatus.OK, null, "1대1 문의 상세 조회 성공", result);
-      
+    }
     @PatchMapping("/{inquiryId}")
     // 인증 인가 구현 후 등록 예정
     // @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/biddingmate/biddinggo/admininquiry/service/AdminInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/admininquiry/service/AdminInquiryServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -94,7 +93,7 @@ public class AdminInquiryServiceImpl implements AdminInquiryService {
         }
 
         return adminInquiryViewDetail;
-
+    }
     @Transactional
     public AnswerAdminInquiryResponse answerAdminInquiry(Long inquiryId, AnswerAdminInquiryRequest request, Long adminId) {
         AdminInquiry adminInquiry = adminInquiryMapper.findById(inquiryId);

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -12,5 +12,7 @@ public interface AuctionMapper extends IMybatisCRUD<Auction> {
 
     void updateAfterBid(@Param("id") Long id, @Param("vickreyPrice") Long vickreyPrice);
 
+    Auction findById(Long auctionId);
+
     Auction findByIdForUpdate(Long auctionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
@@ -4,12 +4,16 @@ import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.service.AuctionInquiryService;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auction Inquiry", description = "경매 문의 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auction/inquiry")
@@ -17,13 +21,21 @@ public class AuctionInquiryController {
 
     private final AuctionInquiryService auctionInquiryService;
 
+    @Operation(summary = "경매 문의 등록", description = "특정 경매에 대해 문의를 등록합니다.")
     @PostMapping("/{auctionId}")
     public ResponseEntity<ApiResponse<CreateAuctionInquiryResponse>> createInquiry(
+
+            @Parameter(description = "문의할 경매 ID", example = "1")
             @PathVariable Long auctionId,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "문의 등록 요청 정보",
+                    required = true
+            )
             @Valid @RequestBody CreateAuctionInquiryRequest request
     ) {
 
-        // TODO: 추후 인증/인가 적용 시 로그인한 사용자 ID로 변경 필요
+        // TODO: 인증/인가 적용 시 로그인 사용자 ID로 변경
         Long writerId = 1L;
 
         CreateAuctionInquiryResponse result =

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
@@ -1,0 +1,39 @@
+package com.biddingmate.biddinggo.auctioninquiry.controller;
+
+import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
+import com.biddingmate.biddinggo.auctioninquiry.service.AuctionInquiryService;
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auction/inquiry")
+public class AuctionInquiryController {
+
+    private final AuctionInquiryService auctionInquiryService;
+
+    @PostMapping("/{auctionId}")
+    public ResponseEntity<ApiResponse<Long>> createInquiry(
+            @PathVariable Long auctionId,
+            @RequestBody CreateAuctionInquiryRequest request
+    ) {
+
+        Long writerId = 1L;
+
+        Long id = auctionInquiryService.createInquiry(
+                auctionId,
+                writerId,
+                request.getContent()
+        );
+
+        return ApiResponse.of(
+                HttpStatus.OK,
+                null,
+                "문의 등록 성공",
+                id
+        );
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
@@ -1,8 +1,10 @@
 package com.biddingmate.biddinggo.auctioninquiry.controller;
 
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
+import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.service.AuctionInquiryService;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,24 +18,26 @@ public class AuctionInquiryController {
     private final AuctionInquiryService auctionInquiryService;
 
     @PostMapping("/{auctionId}")
-    public ResponseEntity<ApiResponse<Long>> createInquiry(
+    public ResponseEntity<ApiResponse<CreateAuctionInquiryResponse>> createInquiry(
             @PathVariable Long auctionId,
-            @RequestBody CreateAuctionInquiryRequest request
+            @Valid @RequestBody CreateAuctionInquiryRequest request
     ) {
 
+        // TODO: 추후 인증/인가 적용 시 로그인한 사용자 ID로 변경 필요
         Long writerId = 1L;
 
-        Long id = auctionInquiryService.createInquiry(
-                auctionId,
-                writerId,
-                request.getContent()
-        );
+        CreateAuctionInquiryResponse result =
+                auctionInquiryService.createInquiry(
+                        auctionId,
+                        writerId,
+                        request.getContent()
+                );
 
         return ApiResponse.of(
                 HttpStatus.OK,
                 null,
                 "문의 등록 성공",
-                id
+                result
         );
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
@@ -1,10 +1,14 @@
 package com.biddingmate.biddinggo.auctioninquiry.dto;
 
-import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@Data
+@Getter
+@AllArgsConstructor
 public class CreateAuctionInquiryRequest {
 
+    @NotBlank(message = "문의 내용은 필수입니다.")
     private String content;
 
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
@@ -1,0 +1,10 @@
+package com.biddingmate.biddinggo.auctioninquiry.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateAuctionInquiryRequest {
+
+    private String content;
+
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.auctioninquiry.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CreateAuctionInquiryRequest {
 
+    @Schema(description = "문의 내용", example = "상품 상태가 어떤가요?", required = true)
     @NotBlank(message = "문의 내용은 필수입니다.")
     private String content;
-
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryResponse.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.auctioninquiry.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,9 +12,18 @@ import java.time.LocalDateTime;
 @Builder
 public class CreateAuctionInquiryResponse {
 
+    @Schema(description = "문의 ID", example = "1")
     private Long id;
+
+    @Schema(description = "경매 ID", example = "10")
     private Long auctionId;
+
+    @Schema(description = "작성자 ID", example = "1")
     private Long writerId;
+
+    @Schema(description = "문의 내용", example = "상품 상태가 어떤가요?")
     private String content;
+
+    @Schema(description = "생성 시간", example = "2026-03-22T12:00:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryResponse.java
@@ -1,0 +1,19 @@
+package com.biddingmate.biddinggo.auctioninquiry.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CreateAuctionInquiryResponse {
+
+    private Long id;
+    private Long auctionId;
+    private Long writerId;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
@@ -15,5 +15,5 @@ public interface AuctionInquiryMapper {
         (#{auctionId}, #{writerId}, #{content}, 'ACTIVE', NOW())
     """)
     @Options(useGeneratedKeys = true, keyProperty = "id")
-    void insertInquiry(AuctionInquiry inquiry);
+    int insertInquiry(AuctionInquiry inquiry);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
@@ -1,19 +1,10 @@
 package com.biddingmate.biddinggo.auctioninquiry.mapper;
 
 import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
-import org.apache.ibatis.annotations.Insert;
+import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Options;
 
 @Mapper
-public interface AuctionInquiryMapper {
+public interface AuctionInquiryMapper extends IMybatisCRUD<AuctionInquiry> {
 
-    @Insert("""
-        INSERT INTO auction_inquiry
-        (auction_id, writer_id, content, status, created_at)
-        VALUES
-        (#{auctionId}, #{writerId}, #{content}, 'ACTIVE', NOW())
-    """)
-    @Options(useGeneratedKeys = true, keyProperty = "id")
-    int insertInquiry(AuctionInquiry inquiry);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
@@ -1,0 +1,19 @@
+package com.biddingmate.biddinggo.auctioninquiry.mapper;
+
+import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+
+@Mapper
+public interface AuctionInquiryMapper {
+
+    @Insert("""
+        INSERT INTO auction_inquiry
+        (auction_id, writer_id, content, status, created_at)
+        VALUES
+        (#{auctionId}, #{writerId}, #{content}, 'ACTIVE', NOW())
+    """)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void insertInquiry(AuctionInquiry inquiry);
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/model/AuctionInquiry.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/model/AuctionInquiry.java
@@ -1,0 +1,21 @@
+package com.biddingmate.biddinggo.auctioninquiry.model;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class AuctionInquiry {
+
+    private Long id;
+    private Long auctionId;
+    private Long writerId;
+    private Long answererId;
+
+    private String content;
+    private String answer;
+
+    private LocalDateTime answeredAt;
+
+    private String status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/model/AuctionInquiry.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/model/AuctionInquiry.java
@@ -1,9 +1,13 @@
 package com.biddingmate.biddinggo.auctioninquiry.model;
 
-import lombok.Data;
+import lombok.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class AuctionInquiry {
 
     private Long id;

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
@@ -1,7 +1,9 @@
 package com.biddingmate.biddinggo.auctioninquiry.service;
 
+import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
+
 public interface AuctionInquiryService {
 
-    Long createInquiry(Long auctionId, Long writerId, String content);
+    CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content);
 
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.auctioninquiry.service;
+
+public interface AuctionInquiryService {
+
+    Long createInquiry(Long auctionId, Long writerId, String content);
+
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -26,14 +26,8 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
     @Override
     @Transactional
     public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content) {
-        System.out.println("검사 시작 - auctionId: " + auctionId + ", writerId: " + writerId);
 
-        // 1. content 검증
-        if (content == null || content.isBlank()) {
-            throw new CustomException(ErrorType.AUCTION_INQUIRY_CONTENT_INVALID);
-        }
-
-        // 2. 경매 존재 여부 검증
+        // 경매 존재 여부 검증
         Auction auction = auctionMapper.findByIdForUpdate(auctionId);
         if (auction == null) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
@@ -44,13 +38,12 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
             throw new CustomException(ErrorType.CANNOT_INQUIRE_OWN_AUCTION);
         }
 
-        // 3. 사용자 존재 여부 검증 (Member 구현 시 연결 가능)
+        // 사용자 존재 여부 검증
 
         Member member = memberMapper.findById(writerId);
         if (member == null) {
             throw new CustomException(ErrorType.NOT_FOUND);
         }
-
 
         Long sellerId = auction.getSellerId();
 

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -1,39 +1,68 @@
 package com.biddingmate.biddinggo.auctioninquiry.service;
 
+import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.mapper.AuctionInquiryMapper;
 import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
+import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
+import com.biddingmate.biddinggo.member.mapper.MemberMapper;
+import com.biddingmate.biddinggo.auction.model.Auction;
+import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class AuctionInquiryServiceImpl implements AuctionInquiryService {
 
     private final AuctionInquiryMapper auctionInquiryMapper;
+    private final AuctionMapper auctionMapper;
+    private final MemberMapper memberMapper;
 
     @Override
-    public Long createInquiry(Long auctionId, Long writerId, String content) {
+    @Transactional
+    public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content) {
 
         // 1. content 검증
         if (content == null || content.isBlank()) {
-            throw new CustomException(ErrorType.BAD_REQUEST);
+            throw new CustomException(ErrorType.AUCTION_INQUIRY_CONTENT_INVALID);
         }
 
-        // 2. auctionId 검증
-        if (auctionId == null) {
-            throw new CustomException(ErrorType.BAD_REQUEST);
+        // 2. 경매 존재 여부 검증
+        Auction auction = auctionMapper.findById(auctionId);
+        if (auction == null) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
         }
 
-        AuctionInquiry inquiry = new AuctionInquiry();
+        // 3. 사용자 존재 여부 검증
+        Member member = memberMapper.findById(writerId);
+        if (member == null) {
+            throw new CustomException(ErrorType.NOT_FOUND);
+        }
 
-        inquiry.setAuctionId(auctionId);
-        inquiry.setWriterId(writerId);
-        inquiry.setContent(content);
+        AuctionInquiry inquiry = AuctionInquiry.builder()
+                .auctionId(auctionId)
+                .writerId(writerId)
+                .content(content)
+                .createdAt(LocalDateTime.now())
+                .build();
 
-        auctionInquiryMapper.insertInquiry(inquiry);
+        int result = auctionInquiryMapper.insertInquiry(inquiry);
 
-        return inquiry.getId();
+        if (result <= 0) {
+            throw new CustomException(ErrorType.AUCTION_INQUIRY_CREATE_FAIL);
+        }
+
+        return CreateAuctionInquiryResponse.builder()
+                .id(inquiry.getId())
+                .auctionId(inquiry.getAuctionId())
+                .writerId(inquiry.getWriterId())
+                .content(inquiry.getContent())
+                .createdAt(inquiry.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -51,7 +51,7 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        int result = auctionInquiryMapper.insertInquiry(inquiry);
+        int result = auctionInquiryMapper.insert(inquiry);
 
         if (result <= 0) {
             throw new CustomException(ErrorType.AUCTION_INQUIRY_CREATE_FAIL);

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -1,0 +1,39 @@
+package com.biddingmate.biddinggo.auctioninquiry.service;
+
+import com.biddingmate.biddinggo.auctioninquiry.mapper.AuctionInquiryMapper;
+import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionInquiryServiceImpl implements AuctionInquiryService {
+
+    private final AuctionInquiryMapper auctionInquiryMapper;
+
+    @Override
+    public Long createInquiry(Long auctionId, Long writerId, String content) {
+
+        // 1. content 검증
+        if (content == null || content.isBlank()) {
+            throw new CustomException(ErrorType.BAD_REQUEST);
+        }
+
+        // 2. auctionId 검증
+        if (auctionId == null) {
+            throw new CustomException(ErrorType.BAD_REQUEST);
+        }
+
+        AuctionInquiry inquiry = new AuctionInquiry();
+
+        inquiry.setAuctionId(auctionId);
+        inquiry.setWriterId(writerId);
+        inquiry.setContent(content);
+
+        auctionInquiryMapper.insertInquiry(inquiry);
+
+        return inquiry.getId();
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -1,14 +1,13 @@
 package com.biddingmate.biddinggo.auctioninquiry.service;
 
+import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
+import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.mapper.AuctionInquiryMapper;
 import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
-import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
-import com.biddingmate.biddinggo.member.mapper.MemberMapper;
-import com.biddingmate.biddinggo.auction.model.Auction;
-import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +25,7 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
     @Override
     @Transactional
     public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content) {
+        System.out.println("검사 시작 - auctionId: " + auctionId + ", writerId: " + writerId);
 
         // 1. content 검증
         if (content == null || content.isBlank()) {
@@ -33,20 +33,33 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
         }
 
         // 2. 경매 존재 여부 검증
-        Auction auction = auctionMapper.findById(auctionId);
+        Auction auction = auctionMapper.findByIdForUpdate(auctionId);
         if (auction == null) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
         }
 
-        // 3. 사용자 존재 여부 검증
-        Member member = memberMapper.findById(writerId);
-        if (member == null) {
-            throw new CustomException(ErrorType.NOT_FOUND);
+        // 본인 경매 문의 제한
+        if (auction.getSellerId().equals(writerId)) {
+            throw new CustomException(ErrorType.CANNOT_INQUIRE_OWN_AUCTION);
         }
+
+        // 3. 사용자 존재 여부 검증 (Member 구현 시 연결 가능)
+        /* [테스트 완료 및 주석 처리]
+
+         */
+    /*
+    Member member = memberMapper.findById(writerId);
+    if (member == null) {
+        throw new CustomException(ErrorType.NOT_FOUND);
+    }
+    */
+
+        Long sellerId = auction.getSellerId();
 
         AuctionInquiry inquiry = AuctionInquiry.builder()
                 .auctionId(auctionId)
                 .writerId(writerId)
+                .answererId(sellerId)
                 .content(content)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -28,7 +28,7 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
     public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content) {
 
         // 경매 존재 여부 검증
-        Auction auction = auctionMapper.findByIdForUpdate(auctionId);
+        Auction auction = auctionMapper.findById(auctionId);
         if (auction == null) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
         }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -8,6 +8,7 @@ import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
+import com.biddingmate.biddinggo.member.model.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,15 +45,12 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
         }
 
         // 3. 사용자 존재 여부 검증 (Member 구현 시 연결 가능)
-        /* [테스트 완료 및 주석 처리]
 
-         */
-    /*
-    Member member = memberMapper.findById(writerId);
-    if (member == null) {
-        throw new CustomException(ErrorType.NOT_FOUND);
-    }
-    */
+        Member member = memberMapper.findById(writerId);
+        if (member == null) {
+            throw new CustomException(ErrorType.NOT_FOUND);
+        }
+
 
         Long sellerId = auction.getSellerId();
 

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -67,7 +67,7 @@ public enum ErrorType {
     // 경매 문의
     AUCTION_INQUIRY_CONTENT_INVALID("auction-inquiry-001", "문의 내용이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     AUCTION_INQUIRY_CREATE_FAIL("auction-inquiry-002", "경매 문의 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR),
-
+    CANNOT_INQUIRE_OWN_AUCTION("auction-inquiry-003", "본인이 등록한 경매에는 문의할 수 없습니다.", HttpStatus.BAD_REQUEST),
     // 입찰
     BID_SAVE_FAILED("bid-001", "입찰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     BID_AMOUNT_TOO_LOW("bid-002", "입찰 금액이 최소 입찰 가능 금액보다 낮습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -64,6 +64,10 @@ public enum ErrorType {
     // 1대1 문의
     ADMIN_INQUIRY_CREATED_FAIL("admin-inquiry-001", "관리자 1대1 문의 생성 실패" , HttpStatus.INTERNAL_SERVER_ERROR),
 
+    // 경매 문의
+    AUCTION_INQUIRY_CONTENT_INVALID("auction-inquiry-001", "문의 내용이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    AUCTION_INQUIRY_CREATE_FAIL("auction-inquiry-002", "경매 문의 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+
     // 입찰
     BID_SAVE_FAILED("bid-001", "입찰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     BID_AMOUNT_TOO_LOW("bid-002", "입찰 금액이 최소 입찰 가능 금액보다 낮습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
+++ b/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/payments/**", "/api/v1/auctions/**", "/api/v1/files/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/payments/**", "/api/v1/auctions/**", "/api/v1/files/**", "/swagger-ui/**", "/v3/api-docs/**","/api/v1/auction/**").permitAll()
                         .anyRequest().authenticated());
 
 

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -12,4 +12,6 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
     void usePoint(@Param("id") Long id, @Param("amount") Long amount);
 
     Long getPointById(@Param("id") Long id);
+
+    Member findById(Long id);
 }

--- a/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
+++ b/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.biddingmate.biddinggo.auctioninquiry.mapper.AuctionInquiryMapper">
+
+    <insert id="insert" parameterType="com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry"
+            keyProperty="id" useGeneratedKeys="true">
+        INSERT INTO auction_inquiry (
+            auction_id,
+            writer_id,
+            answerer_id,
+            content,
+            created_at
+        ) VALUES (
+                     #{auctionId},
+                     #{writerId},
+                     #{answererId},
+                     #{content},
+                     #{createdAt}
+                 )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -106,6 +106,29 @@
         WHERE a.id = #{auctionId}
     </select>
 
+    <select id="findById" parameterType="long" resultType="com.biddingmate.biddinggo.auction.model.Auction">
+        SELECT id,
+               item_id AS itemId,
+               winner_id AS winnerId,
+               seller_id AS sellerId,
+               type,
+               inspection_yn AS inspectionYn,
+               status,
+               start_price AS startPrice,
+               bid_unit AS bidUnit,
+               vickrey_price AS vickreyPrice,
+               bid_count AS bidCount,
+               buy_now_price AS buyNowPrice,
+               wish_count AS wishCount,
+               start_date AS startDate,
+               end_date AS endDate,
+               cancel_date AS cancelDate,
+               winner_price AS winnerPrice,
+               created_at AS createdAt
+        FROM auction
+        WHERE id = #{auctionId}
+    </select>
+
     <select id="findByIdForUpdate" parameterType="long" resultType="Auction">
         SELECT id,
                item_id AS itemId,

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -72,9 +72,4 @@
             point >= #{amount};
     </update>
 
-    <select id="findById" resultType="com.biddingmate.biddinggo.member.model.Member">
-        SELECT *
-        FROM member
-        WHERE id = #{id}
-    </select>
 </mapper>

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -28,4 +28,9 @@
             point >= #{amount};
     </update>
 
+    <select id="findById" resultType="com.biddingmate.biddinggo.member.model.Member">
+        SELECT *
+        FROM member
+        WHERE id = #{id}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 경매 문의 등록 API 구현: 특정 경매 아이템에 대해 사용자가 문의 내용을 남길 수 있는 기능을 추가했습니다.
- 데이터 유효성 검증: 문의 내용(content)의 null 및 공백 체크 로직을 적용했습니다.
- 비즈니스 예외 처리: 존재하지 않는 경매 ID(auctionId)로 요청 시 AUCTION_NOT_FOUND 예외가 발생합니다.
- 본인 경매 문의 제한: 판매자가 본인이 등록한 경매에 직접 문의를 남길 수 없도록 차단 로직을 구현했습니다.
- 존재하지 않는 회원 검증: MemberMapper를 통해 유효한 회원인지 확인하는 로직을 구현했습니다.

---

## 📎 관련 이슈
close #41 