### PR TITLE
feat: 검수물품 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -52,6 +52,7 @@ public enum ErrorType {
     INVALID_INSPECTION_STATUS("inspection-004", "현재 검수 상태에서는 처리할 수 없습니다.", HttpStatus.CONFLICT),
     INSPECTION_SHIPPING_INFO_ALREADY_EXISTS("inspection-005", "이미 배송 정보가 등록된 검수입니다.", HttpStatus.CONFLICT),
     INSPECTION_SHIPPING_UPDATE_FAILED("inspection-006", "검수 배송 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_INSPECTION_LIST_REQUEST("inspection-007", "검수물품 목록 조회 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -53,6 +53,7 @@ public enum ErrorType {
     INSPECTION_SHIPPING_INFO_ALREADY_EXISTS("inspection-005", "이미 배송 정보가 등록된 검수입니다.", HttpStatus.CONFLICT),
     INSPECTION_SHIPPING_UPDATE_FAILED("inspection-006", "검수 배송 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_INSPECTION_LIST_REQUEST("inspection-007", "검수물품 목록 조회 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_INSPECTION_LIST_STATUS("inspection-008", "검수물품 상태값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.inspection.controller;
 
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
@@ -24,8 +25,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/inspections")
 @RequiredArgsConstructor
@@ -37,10 +36,10 @@ public class InspectionController {
 
     @GetMapping("")
     @Operation(summary = "검수물품 목록 조회", description = "회원별 검수물품 목록을 조회하고, 선택한 검수 상태로 필터링합니다.")
-    public ResponseEntity<ApiResponse<List<InspectionListResponse>>> getInspectionList(
+    public ResponseEntity<ApiResponse<PageResponse<InspectionListResponse>>> getInspectionList(
             @Valid InspectionListRequest request) {
 
-        List<InspectionListResponse> result = inspectionQueryService.getInspectionList(request);
+        PageResponse<InspectionListResponse> result = inspectionQueryService.getInspectionList(request);
 
         return ApiResponse.of(HttpStatus.OK, null, "검수물품 목록 조회 완료", result);
     }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/InspectionController.java
@@ -3,6 +3,8 @@ package com.biddingmate.biddinggo.inspection.controller;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionRequest;
 import com.biddingmate.biddinggo.inspection.dto.CreateInspectionResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
 import com.biddingmate.biddinggo.inspection.dto.UpdateInspectionShippingRequest;
 import com.biddingmate.biddinggo.inspection.service.InspectionApplicationService;
 import com.biddingmate.biddinggo.inspection.service.InspectionService;
@@ -22,6 +24,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/inspections")
 @RequiredArgsConstructor
@@ -30,6 +34,16 @@ public class InspectionController {
     private final InspectionApplicationService inspectionApplicationService;
     private final InspectionService inspectionService;
     private final InspectionQueryService inspectionQueryService;
+
+    @GetMapping("")
+    @Operation(summary = "검수물품 목록 조회", description = "회원별 검수물품 목록을 조회하고, 선택한 검수 상태로 필터링합니다.")
+    public ResponseEntity<ApiResponse<List<InspectionListResponse>>> getInspectionList(
+            @Valid InspectionListRequest request) {
+
+        List<InspectionListResponse> result = inspectionQueryService.getInspectionList(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "검수물품 목록 조회 완료", result);
+    }
 
     @GetMapping("/{inspectionId}")
     @Operation(summary = "검수 아이템 상세 조회", description = "검수 정보, 상품 정보, 카테고리, 이미지 목록을 조회합니다.")

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListRequest.java
@@ -1,0 +1,27 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "검수물품 목록 조회 요청 DTO")
+public class InspectionListRequest {
+    @Schema(description = "회원 ID", example = "1")
+    @NotNull(message = "회원 ID는 필수입니다.")
+    @Positive(message = "회원 ID는 1 이상이어야 합니다.")
+    private Long memberId;
+
+    @Schema(description = "검수 상태", example = "PENDING", nullable = true)
+    private ItemInspectionStatus status;
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListRequest.java
@@ -1,21 +1,22 @@
 package com.biddingmate.biddinggo.inspection.dto;
 
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @Schema(description = "검수물품 목록 조회 요청 DTO")
-public class InspectionListRequest {
+public class InspectionListRequest extends BasePageRequest {
     @Schema(description = "회원 ID", example = "1")
     @NotNull(message = "회원 ID는 필수입니다.")
     @Positive(message = "회원 ID는 1 이상이어야 합니다.")

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListRequest.java
@@ -1,6 +1,5 @@
 package com.biddingmate.biddinggo.inspection.dto;
 
-import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -23,5 +22,5 @@ public class InspectionListRequest {
     private Long memberId;
 
     @Schema(description = "검수 상태", example = "PENDING", nullable = true)
-    private ItemInspectionStatus status;
+    private String status;
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionListResponse.java
@@ -1,0 +1,49 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "검수물품 목록 조회 응답 DTO")
+public class InspectionListResponse {
+    @Schema(description = "검수 ID", example = "12")
+    private Long inspectionId;
+
+    @Schema(description = "상품 ID", example = "10")
+    private Long itemId;
+
+    @Schema(description = "브랜드명", example = "Nike")
+    private String brand;
+
+    @Schema(description = "상품명", example = "Air Jordan 1 High")
+    private String name;
+
+    @Schema(description = "상품 상태", example = "최상")
+    private String quality;
+
+    @Schema(description = "검수 상태", example = "PENDING")
+    private ItemInspectionStatus inspectionStatus;
+
+    @Schema(description = "대표 이미지 URL", nullable = true)
+    private String representativeImageUrl;
+
+    @Schema(description = "택배사", nullable = true)
+    private String carrier;
+
+    @Schema(description = "송장 번호", nullable = true)
+    private String trackingNumber;
+
+    @Schema(description = "검수 등록일시")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
@@ -8,6 +8,7 @@ import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
 import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.session.RowBounds;
 
 import java.util.List;
 
@@ -20,8 +21,12 @@ public interface InspectionMapper extends IMybatisCRUD<Inspection> {
             @Param("currentStatus") InspectionStatus currentStatus
     );
 
-    List<InspectionListResponse> findInspectionList(@Param("memberId") Long memberId,
+    List<InspectionListResponse> findInspectionList(RowBounds rowBounds,
+                                                    @Param("memberId") Long memberId,
                                                     @Param("status") ItemInspectionStatus status);
+
+    int countInspectionList(@Param("memberId") Long memberId,
+                            @Param("status") ItemInspectionStatus status);
 
     InspectionDetailResponse findDetailById(Long inspectionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
@@ -2,10 +2,14 @@ package com.biddingmate.biddinggo.inspection.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
 import com.biddingmate.biddinggo.inspection.model.Inspection;
 import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
+import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface InspectionMapper extends IMybatisCRUD<Inspection> {
@@ -15,5 +19,9 @@ public interface InspectionMapper extends IMybatisCRUD<Inspection> {
             @Param("trackingNumber") String trackingNumber,
             @Param("currentStatus") InspectionStatus currentStatus
     );
+
+    List<InspectionListResponse> findInspectionList(@Param("memberId") Long memberId,
+                                                    @Param("status") ItemInspectionStatus status);
+
     InspectionDetailResponse findDetailById(Long inspectionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
@@ -1,10 +1,9 @@
 package com.biddingmate.biddinggo.inspection.service;
 
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
-
-import java.util.List;
 
 /**
  * 검수 조회 전용 서비스.
@@ -14,7 +13,7 @@ public interface InspectionQueryService {
     /**
      * 회원 ID와 선택한 검수 상태를 기준으로 검수물품 목록을 조회한다.
      */
-    List<InspectionListResponse> getInspectionList(InspectionListRequest request);
+    PageResponse<InspectionListResponse> getInspectionList(InspectionListRequest request);
 
     /**
      * 검수 ID를 기준으로 상세 정보를 조회한다.

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
@@ -1,12 +1,21 @@
 package com.biddingmate.biddinggo.inspection.service;
 
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
+
+import java.util.List;
 
 /**
  * 검수 조회 전용 서비스.
  * 등록/수정 로직과 분리하여 읽기 책임만 담당한다.
  */
 public interface InspectionQueryService {
+    /**
+     * 회원 ID와 선택한 검수 상태를 기준으로 검수물품 목록을 조회한다.
+     */
+    List<InspectionListResponse> getInspectionList(InspectionListRequest request);
+
     /**
      * 검수 ID를 기준으로 상세 정보를 조회한다.
      */

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.biddingmate.biddinggo.inspection.service;
 
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
@@ -9,6 +10,7 @@ import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
 import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
 import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,14 +28,23 @@ public class InspectionQueryServiceImpl implements InspectionQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<InspectionListResponse> getInspectionList(InspectionListRequest request) {
+    public PageResponse<InspectionListResponse> getInspectionList(InspectionListRequest request) {
         if (request.getMemberId() == null || request.getMemberId() <= 0) {
             throw new CustomException(ErrorType.INVALID_INSPECTION_LIST_REQUEST);
         }
 
-        ItemInspectionStatus status = parseInspectionStatus(request.getStatus());
+        String order = request.getOrder();
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
 
-        return inspectionMapper.findInspectionList(request.getMemberId(), status);
+        ItemInspectionStatus status = parseInspectionStatus(request.getStatus());
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+
+        List<InspectionListResponse> list = inspectionMapper.findInspectionList(rowBounds, request.getMemberId(), status);
+        int count = inspectionMapper.countInspectionList(request.getMemberId(), status);
+
+        return PageResponse.of(list, request.getPage(), request.getSize(), count);
     }
 
     private ItemInspectionStatus parseInspectionStatus(String status) {

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.biddingmate.biddinggo.inspection.service;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
 import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
 import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,16 @@ import java.util.List;
 public class InspectionQueryServiceImpl implements InspectionQueryService {
     private final InspectionMapper inspectionMapper;
     private final ItemImageMapper itemImageMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<InspectionListResponse> getInspectionList(InspectionListRequest request) {
+        if (request.getMemberId() == null || request.getMemberId() <= 0) {
+            throw new CustomException(ErrorType.INVALID_INSPECTION_LIST_REQUEST);
+        }
+
+        return inspectionMapper.findInspectionList(request.getMemberId(), request.getStatus());
+    }
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
 import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
 import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
+import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +31,21 @@ public class InspectionQueryServiceImpl implements InspectionQueryService {
             throw new CustomException(ErrorType.INVALID_INSPECTION_LIST_REQUEST);
         }
 
-        return inspectionMapper.findInspectionList(request.getMemberId(), request.getStatus());
+        ItemInspectionStatus status = parseInspectionStatus(request.getStatus());
+
+        return inspectionMapper.findInspectionList(request.getMemberId(), status);
+    }
+
+    private ItemInspectionStatus parseInspectionStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+
+        try {
+            return ItemInspectionStatus.valueOf(status.trim().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new CustomException(ErrorType.INVALID_INSPECTION_LIST_STATUS);
+        }
     }
 
     @Override

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -3,6 +3,19 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.biddingmate.biddinggo.inspection.mapper.InspectionMapper">
 
+    <resultMap id="inspectionListResultMap" type="com.biddingmate.biddinggo.inspection.dto.InspectionListResponse">
+        <id property="inspectionId" column="inspection_id"/>
+        <result property="itemId" column="item_id"/>
+        <result property="brand" column="brand"/>
+        <result property="name" column="name"/>
+        <result property="quality" column="quality"/>
+        <result property="inspectionStatus" column="inspection_status"/>
+        <result property="representativeImageUrl" column="representative_image_url"/>
+        <result property="carrier" column="carrier"/>
+        <result property="trackingNumber" column="tracking_number"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
     <resultMap id="inspectionResultMap" type="Inspection">
         <id property="id" column="id"/>
         <result property="itemId" column="item_id"/>
@@ -52,6 +65,33 @@
             created_at
         FROM inspection
         WHERE id = #{id}
+    </select>
+
+    <select id="findInspectionList" parameterType="map" resultMap="inspectionListResultMap">
+        SELECT
+            i.id AS inspection_id,
+            ai.id AS item_id,
+            ai.brand,
+            ai.name,
+            ai.quality,
+            ai.inspection_status,
+            ii.url AS representative_image_url,
+            i.carrier,
+            i.tracking_number,
+            i.created_at
+        FROM inspection i
+        INNER JOIN auction_item ai ON i.item_id = ai.id
+        LEFT JOIN item_image ii ON ii.item_id = ai.id
+            AND ii.display_order = (
+                SELECT MIN(ii2.display_order)
+                FROM item_image ii2
+                WHERE ii2.item_id = ai.id
+            )
+        WHERE ai.seller_id = #{memberId}
+        <if test="status != null">
+            AND ai.inspection_status = #{status}
+        </if>
+        ORDER BY i.created_at DESC
     </select>
 
     <update id="updateShippingInfo">

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -94,6 +94,16 @@
         ORDER BY i.created_at DESC
     </select>
 
+    <select id="countInspectionList" parameterType="map" resultType="_int">
+        SELECT COUNT(*)
+        FROM inspection i
+        INNER JOIN auction_item ai ON i.item_id = ai.id
+        WHERE ai.seller_id = #{memberId}
+        <if test="status != null">
+            AND ai.inspection_status = #{status}
+        </if>
+    </select>
+
     <update id="updateShippingInfo">
         UPDATE inspection
         SET carrier = #{carrier},


### PR DESCRIPTION
## 📌 PR 유형

- [x] Feature (새로운 기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

———

## 📝 작업 내용

- 검수물품 목록 조회 API GET /api/v1/inspections를 추가했습니다.
- memberId를 기준으로 해당 유저의 검수물품만 조회하도록 구현했습니다.
- status를 선택값으로 받아 auction_item.inspection_status 기준 필터링할 수 있도록 구현했습니다.
- 목록 응답에 대표 이미지, 배송 정보, 상품 기본 정보, 검수 상태를 포함하도록 구성했습니다.
- status는 문자열로 입력받고 서비스 계층에서 직접 파싱하도록 변경하여, 잘못된 상태값 요청 시 커스텀 에러 메시지를 반환하도록 처리했습니다.
- 검수물품 목록 조회 요청 전용 에러 코드 INVALID_INSPECTION_LIST_REQUEST, INVALID_INSPECTION_LIST_STATUS를 추가했습니다.
- 전체 변경 후 bash gradlew compileJava로 컴파일 검증을 완료했습니다.

———

## 📎 관련 이슈

- resolves #43 
