### PR TITLE
feat: 경매 정보 수정 및 취소 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
@@ -1,11 +1,14 @@
 package com.biddingmate.biddinggo.auction.controller;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.auction.dto.CancelAuctionRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionFromInspectionItemRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionResponse;
+import com.biddingmate.biddinggo.auction.dto.UpdateAuctionRequest;
 import com.biddingmate.biddinggo.auction.service.AuctionApplicationService;
 import com.biddingmate.biddinggo.auction.service.AuctionQueryService;
+import com.biddingmate.biddinggo.auction.service.AuctionService;
 import io.swagger.v3.oas.annotations.Operation;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuctionController {
     private final AuctionApplicationService auctionApplicationService;
     private final AuctionQueryService auctionQueryService;
+    private final AuctionService auctionService;
 
     @GetMapping("/{auctionId}")
     @Operation(summary = "경매 상세 조회", description = "경매 기본 정보, 상품 정보, 카테고리, 이미지 목록을 조회합니다.")
@@ -64,5 +69,35 @@ public class AuctionController {
                 .build();
 
         return ApiResponse.of(HttpStatus.OK, null, "검수 완료 상품 경매 등록 완료", result);
+    }
+
+    @PatchMapping("/{auctionId}")
+    @Operation(summary = "경매 정보 수정", description = "경매 정보를 수정합니다.")
+    public ResponseEntity<ApiResponse<CreateAuctionResponse>> updateAuction(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody UpdateAuctionRequest request) {
+
+        auctionService.updateAuction(auctionId, request);
+
+        CreateAuctionResponse result = CreateAuctionResponse.builder()
+                .auctionId(auctionId)
+                .build();
+
+        return ApiResponse.of(HttpStatus.OK, null, "경매 정보 수정 완료", result);
+    }
+
+    @PatchMapping("/{auctionId}/cancel")
+    @Operation(summary = "경매 취소", description = "경매를 취소 처리합니다.")
+    public ResponseEntity<ApiResponse<CreateAuctionResponse>> cancelAuction(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody CancelAuctionRequest request) {
+
+        auctionService.cancelAuction(auctionId, request.getSellerId());
+
+        CreateAuctionResponse result = CreateAuctionResponse.builder()
+                .auctionId(auctionId)
+                .build();
+
+        return ApiResponse.of(HttpStatus.OK, null, "경매 취소 완료", result);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/CancelAuctionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/CancelAuctionRequest.java
@@ -1,0 +1,21 @@
+package com.biddingmate.biddinggo.auction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "경매 취소 요청 DTO")
+public class CancelAuctionRequest {
+    @Schema(description = "판매자 ID", example = "1")
+    @NotNull(message = "판매자 ID는 필수입니다.")
+    private Long sellerId;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/UpdateAuctionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/UpdateAuctionRequest.java
@@ -1,0 +1,49 @@
+package com.biddingmate.biddinggo.auction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "경매 수정 요청 DTO")
+public class UpdateAuctionRequest {
+    @Schema(description = "판매자 ID", example = "1")
+    @NotNull(message = "판매자 ID는 필수입니다.")
+    private Long sellerId;
+
+    @Schema(description = "시작가", example = "100000")
+    @PositiveOrZero(message = "시작가는 0 이상이어야 합니다.")
+    private Long startPrice;
+
+    @Schema(description = "입찰 단위", example = "1000")
+    @Positive(message = "입찰 단위는 1 이상이어야 합니다.")
+    private Integer bidUnit;
+
+    @Schema(description = "비크리 가격", example = "150000", nullable = true)
+    @PositiveOrZero(message = "비크리 가격은 0 이상이어야 합니다.")
+    private Long vickreyPrice;
+
+    @Schema(description = "즉시 구매가", example = "180000", nullable = true)
+    @PositiveOrZero(message = "즉시 구매가는 0 이상이어야 합니다.")
+    private Long buyNowPrice;
+
+    @Schema(description = "경매 시작일시", example = "2026-03-15T10:00:00")
+    @NotNull(message = "경매 시작일시는 필수입니다.")
+    private LocalDateTime startDate;
+
+    @Schema(description = "경매 종료일시", example = "2026-03-16T10:00:00")
+    @NotNull(message = "경매 종료일시는 필수입니다.")
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/UpdateAuctionRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/UpdateAuctionRequest.java
@@ -31,10 +31,6 @@ public class UpdateAuctionRequest {
     @Positive(message = "입찰 단위는 1 이상이어야 합니다.")
     private Integer bidUnit;
 
-    @Schema(description = "비크리 가격", example = "150000", nullable = true)
-    @PositiveOrZero(message = "비크리 가격은 0 이상이어야 합니다.")
-    private Long vickreyPrice;
-
     @Schema(description = "즉시 구매가", example = "180000", nullable = true)
     @PositiveOrZero(message = "즉시 구매가는 0 이상이어야 합니다.")
     private Long buyNowPrice;

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -2,13 +2,22 @@ package com.biddingmate.biddinggo.auction.mapper;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.auction.model.Auction;
+import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
+
 @Mapper
 public interface AuctionMapper extends IMybatisCRUD<Auction> {
     AuctionDetailResponse findDetailById(Long auctionId);
+
+    int updateAuction(Auction auction);
+
+    int cancelAuction(@Param("auctionId") Long auctionId,
+                      @Param("cancelDate") LocalDateTime cancelDate,
+                      @Param("newStatus") AuctionStatus newStatus);
 
     void updateAfterBid(@Param("id") Long id, @Param("vickreyPrice") Long vickreyPrice);
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionService.java
@@ -2,6 +2,7 @@ package com.biddingmate.biddinggo.auction.service;
 
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionFromInspectionItemRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
+import com.biddingmate.biddinggo.auction.dto.UpdateAuctionRequest;
 
 /**
  * auction 테이블 저장 책임을 담당하는 서비스.
@@ -16,4 +17,14 @@ public interface AuctionService {
      * 검수 완료된 기존 itemId를 기준으로 auction 데이터를 저장한다.
      */
     Long createAuction(CreateAuctionFromInspectionItemRequest request);
+
+    /**
+     * 경매 정보를 수정한다.
+     */
+    void updateAuction(Long auctionId, UpdateAuctionRequest request);
+
+    /**
+     * 경매를 취소 처리한다.
+     */
+    void cancelAuction(Long auctionId, Long sellerId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
@@ -2,13 +2,16 @@ package com.biddingmate.biddinggo.auction.service;
 
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionFromInspectionItemRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
+import com.biddingmate.biddinggo.auction.dto.UpdateAuctionRequest;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
+import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.auction.model.YesNo;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -20,6 +23,55 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class AuctionServiceImpl implements AuctionService {
     private final AuctionMapper auctionMapper;
+
+    @Override
+    @Transactional
+    public void updateAuction(Long auctionId, UpdateAuctionRequest request) {
+        validateUpdateRequest(auctionId, request);
+
+        Auction auction = getAuctionForModification(auctionId);
+        validateSeller(auction, request.getSellerId());
+
+        if (!isAuctionUpdatableOrCancelable(auction)) {
+            throw new CustomException(ErrorType.AUCTION_UPDATE_NOT_ALLOWED);
+        }
+
+        Auction updateTarget = Auction.builder()
+                .id(auctionId)
+                .startPrice(request.getStartPrice())
+                .bidUnit(request.getBidUnit())
+                .buyNowPrice(request.getBuyNowPrice())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .build();
+
+        int updatedCount = auctionMapper.updateAuction(updateTarget);
+
+        if (updatedCount != 1) {
+            throw new CustomException(ErrorType.AUCTION_UPDATE_NOT_ALLOWED);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void cancelAuction(Long auctionId, Long sellerId) {
+        if (auctionId == null || auctionId <= 0 || sellerId == null || sellerId <= 0) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_CANCEL_REQUEST);
+        }
+
+        Auction auction = getAuctionForModification(auctionId);
+        validateSeller(auction, sellerId);
+
+        if (!isAuctionUpdatableOrCancelable(auction)) {
+            throw new CustomException(ErrorType.AUCTION_CANCEL_NOT_ALLOWED);
+        }
+
+        int updatedCount = auctionMapper.cancelAuction(auctionId, LocalDateTime.now(), AuctionStatus.CANCELLED);
+
+        if (updatedCount != 1) {
+            throw new CustomException(ErrorType.AUCTION_CANCEL_NOT_ALLOWED);
+        }
+    }
 
     @Override
     public Long createAuction(CreateAuctionRequest request, Long itemId) {
@@ -80,5 +132,46 @@ public class AuctionServiceImpl implements AuctionService {
         }
 
         return auction.getId();
+    }
+
+    private void validateUpdateRequest(Long auctionId, UpdateAuctionRequest request) {
+        if (auctionId == null || auctionId <= 0 || request == null) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_UPDATE_REQUEST);
+        }
+
+        if (request.getSellerId() == null || request.getSellerId() <= 0) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_UPDATE_REQUEST);
+        }
+
+        if (request.getStartPrice() == null || request.getBidUnit() == null
+                || request.getStartDate() == null || request.getEndDate() == null) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_UPDATE_REQUEST);
+        }
+    }
+
+    private Auction getAuctionForModification(Long auctionId) {
+        Auction auction = auctionMapper.findByIdForUpdate(auctionId);
+
+        if (auction == null) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
+        }
+
+        return auction;
+    }
+
+    private void validateSeller(Auction auction, Long sellerId) {
+        if (!auction.getSellerId().equals(sellerId)) {
+            throw new CustomException(ErrorType.FORBIDDEN);
+        }
+    }
+
+    private boolean isAuctionUpdatableOrCancelable(Auction auction) {
+        if (auction.getStatus() == AuctionStatus.PENDING) {
+            return true;
+        }
+
+        return auction.getStatus() == AuctionStatus.ON_GOING
+                && auction.getBidCount() != null
+                && auction.getBidCount() == 0;
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
@@ -26,16 +26,23 @@ public class AuctionServiceImpl implements AuctionService {
 
     @Override
     @Transactional
+    /**
+     * 경매 수정 메인 로직.
+     * 판매자 본인 여부와 수정 가능 상태를 확인한 뒤 auction 테이블의 수정 가능 필드만 반영한다.
+     */
     public void updateAuction(Long auctionId, UpdateAuctionRequest request) {
         validateUpdateRequest(auctionId, request);
 
+        // 동시 수정 충돌을 줄이기 위해 수정 대상 경매를 lock 조회한다.
         Auction auction = getAuctionForModification(auctionId);
         validateSeller(auction, request.getSellerId());
 
+        // 정책상 PENDING 또는 ON_GOING + bidCount == 0 인 경우에만 수정 가능하다.
         if (!isAuctionUpdatableOrCancelable(auction)) {
             throw new CustomException(ErrorType.AUCTION_UPDATE_NOT_ALLOWED);
         }
 
+        // 현재 정책상 경매 메타 정보(가격/일정)만 수정 대상으로 둔다.
         Auction updateTarget = Auction.builder()
                 .id(auctionId)
                 .startPrice(request.getStartPrice())
@@ -54,14 +61,20 @@ public class AuctionServiceImpl implements AuctionService {
 
     @Override
     @Transactional
+    /**
+     * 경매 취소 메인 로직.
+     * 판매자 본인 여부와 취소 가능 상태를 확인한 뒤 status와 cancel_date를 함께 갱신한다.
+     */
     public void cancelAuction(Long auctionId, Long sellerId) {
         if (auctionId == null || auctionId <= 0 || sellerId == null || sellerId <= 0) {
             throw new CustomException(ErrorType.INVALID_AUCTION_CANCEL_REQUEST);
         }
 
+        // 취소 직전 상태를 정확히 확인하기 위해 lock 조회한다.
         Auction auction = getAuctionForModification(auctionId);
         validateSeller(auction, sellerId);
 
+        // 수정과 동일한 정책으로 취소 가능 여부를 판단한다.
         if (!isAuctionUpdatableOrCancelable(auction)) {
             throw new CustomException(ErrorType.AUCTION_CANCEL_NOT_ALLOWED);
         }
@@ -134,6 +147,10 @@ public class AuctionServiceImpl implements AuctionService {
         return auction.getId();
     }
 
+    /**
+     * 수정 요청 기본값을 검증한다.
+     * 경매 ID, 판매자 ID, 수정 필수 필드가 비어 있으면 요청 오류로 처리한다.
+     */
     private void validateUpdateRequest(Long auctionId, UpdateAuctionRequest request) {
         if (auctionId == null || auctionId <= 0 || request == null) {
             throw new CustomException(ErrorType.INVALID_AUCTION_UPDATE_REQUEST);
@@ -149,6 +166,9 @@ public class AuctionServiceImpl implements AuctionService {
         }
     }
 
+    /**
+     * 수정/취소 대상 경매를 배타적으로 조회한다.
+     */
     private Auction getAuctionForModification(Long auctionId) {
         Auction auction = auctionMapper.findByIdForUpdate(auctionId);
 
@@ -159,12 +179,19 @@ public class AuctionServiceImpl implements AuctionService {
         return auction;
     }
 
+    /**
+     * 요청 판매자와 실제 경매 판매자가 같은지 검증한다.
+     */
     private void validateSeller(Auction auction, Long sellerId) {
         if (!auction.getSellerId().equals(sellerId)) {
             throw new CustomException(ErrorType.FORBIDDEN);
         }
     }
 
+    /**
+     * 경매 수정/취소 가능 여부를 판단한다.
+     * PENDING 은 항상 허용하고, ON_GOING 은 입찰 수가 0일 때만 허용한다.
+     */
     private boolean isAuctionUpdatableOrCancelable(Auction auction) {
         if (auction.getStatus() == AuctionStatus.PENDING) {
             return true;

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -44,6 +44,10 @@ public enum ErrorType {
     AUCTION_ITEM_SELLER_MISMATCH("auction-010", "상품 판매자와 요청 판매자가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
     INSPECTION_NOT_PASSED("auction-011", "검수 완료된 상품만 경매 등록할 수 있습니다.", HttpStatus.CONFLICT),
     ITEM_NOT_AUCTIONABLE("auction-012", "현재 상태에서는 경매 등록할 수 없습니다.", HttpStatus.CONFLICT),
+    INVALID_AUCTION_UPDATE_REQUEST("auction-013", "경매 수정 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_AUCTION_CANCEL_REQUEST("auction-014", "경매 취소 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    AUCTION_UPDATE_NOT_ALLOWED("auction-015", "현재 상태에서는 경매를 수정할 수 없습니다.", HttpStatus.CONFLICT),
+    AUCTION_CANCEL_NOT_ALLOWED("auction-016", "현재 상태에서는 경매를 취소할 수 없습니다.", HttpStatus.CONFLICT),
 
     // 검수
     INVALID_INSPECTION_CREATE_REQUEST("inspection-001", "검수 등록 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -136,4 +136,21 @@
             bid_count = bid_count+1
         WHERE id = #{id}
     </update>
+
+    <update id="updateAuction" parameterType="Auction">
+        UPDATE auction
+        SET start_price = #{startPrice},
+            bid_unit = #{bidUnit},
+            buy_now_price = #{buyNowPrice},
+            start_date = #{startDate},
+            end_date = #{endDate}
+        WHERE id = #{id}
+    </update>
+
+    <update id="cancelAuction" parameterType="map">
+        UPDATE auction
+        SET status = #{newStatus},
+            cancel_date = #{cancelDate}
+        WHERE id = #{auctionId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형

- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

———

## 📝 작업 내용

- 경매 수정 API PATCH /api/v1/auctions/{auctionId}를 추가했습니다.
- 경매 취소 API PATCH /api/v1/auctions/{auctionId}/cancel를 추가했습니다.
- 경매 수정 요청 DTO UpdateAuctionRequest와 취소 요청 DTO CancelAuctionRequest를 추가했습니다.
- AuctionService, AuctionMapper, MyBatis XML에 경매 수정/취소 로직을 추가했습니다.
- 판매자 본인 여부를 검증하도록 구현했습니다.
- 경매 상태가 PENDING이거나 ON_GOING이면서 bid_count == 0인 경우에만 수정/취소 가능하도록 처리했습니다.
- 경매 취소 시 status를 CANCELLED로 변경하고 cancel_date를 저장하도록 구현했습니다.
- 경매 수정/취소 요청 및 상태 검증용 커스텀 에러 코드를 추가했습니다.
- 관련 서비스 메서드에 정책과 흐름을 설명하는 주석을 보강했습니다.

———

## 📎 관련 이슈

- resolves #59 