### PR TITLE
fix: 차순위 입찰이 없는 경우에도 경매 갱신되도록 수정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/bid/service/BidApplicationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/bid/service/BidApplicationServiceImpl.java
@@ -70,10 +70,10 @@ public class BidApplicationServiceImpl implements BidApplicationService {
         // 4. Auction 정보 갱신 : 경매 차순위 값 변경 + 입찰 수 증가
         // 추후 AuctionService 구현 이후 변경
         Bid vickreyBid = bidService.getVickreyBid(auctionId);
-        if(vickreyBid != null){
-            auctionMapper.updateAfterBid(auctionId, vickreyBid.getAmount());
-        }
-
+        auctionMapper.updateAfterBid(
+                auctionId,
+                vickreyBid != null ? vickreyBid.getAmount() : null
+        );
 
         // 5. Point History 저장
         // 추후 PointHistoryService 구현 이후 변경

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -155,7 +155,8 @@
 
     <update id="updateAfterBid" parameterType="map">
         UPDATE auction
-        SET vickrey_price = #{vickreyPrice},
+        SET
+            <if test="vickreyPrice != null"> vickrey_price = #{vickreyPrice},</if>
             bid_count = bid_count+1
         WHERE id = #{id}
     </update>


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 차순위 입찰이 없는 경우에도 경매 정보가 정상적으로 갱신되도록 수정했습니다.
- vickreyPrice가 null일 경우 해당 컬럼은 업데이트하지 않도록 쿼리를 수정했습니다.
- bid_count는 항상 증가하도록 처리했습니다.

---

## 📎 관련 이슈
- close #64 