### PR TITLE
feat: 회원 대시보드 조회 API 수정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberBiddingItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberBiddingItemResponse.java
@@ -1,0 +1,18 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberBiddingItemResponse {
+    private String imageUrl;
+    private String itemName;
+    private Long currentPrice;
+    private Long myBidPrice;
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberDashboardResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberDashboardResponse.java
@@ -5,14 +5,24 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MemberDashboardResponse {
-    private Long totalPurchaseAmount;
 
-    private Long totalSalesAmount;
-
+    // 대시보드에 노출될 회원 정보
+    private String nickname;
+    private String grade;
     private Long point;
+
+    // 낙찰된 물품 목록
+    private List<MemberWonItemResponse> wonItems;
+
+    // 입찰 중 물품 목록
+    private List<MemberBiddingItemResponse> biddingItems;
+
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberWonItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberWonItemResponse.java
@@ -1,0 +1,16 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberWonItemResponse {
+    private String imageUrl;
+    private String itemName;
+    private String deliveryStatus;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -1,17 +1,19 @@
 package com.biddingmate.biddinggo.member.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
+import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 @Mapper
 public interface MemberMapper extends IMybatisCRUD<Member> {
     void addPoint(@Param("id") Long id, @Param("amount") Long amount);
-
-    MemberDashboardResponse findDashboardById(@Param("memberId") Long memberId);
 
     void usePoint(@Param("id") Long id, @Param("amount") Long amount);
 
@@ -19,4 +21,12 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
 
     MemberProfileResponse findProfileById(@Param("memberId") Long memberId);
 
+    // 대시보드
+    MemberDashboardResponse findDashboardInfoById(@Param("memberId") Long memberId);
+
+    // 낙찰된 물품 목록
+    List<MemberWonItemResponse> findWonItemsById(@Param("memberId") Long memberId);
+
+    // 입찰 중 물품 목록
+    List<MemberBiddingItemResponse> findBiddingItemsById(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -4,7 +4,7 @@ import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 
 public interface MemberService {
-    MemberDashboardResponse getMyDashboard(Long memberId);
+    MemberDashboardResponse getMyDashboard(Long id);
 
     MemberProfileResponse getMyProfile(Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -2,15 +2,16 @@ package com.biddingmate.biddinggo.member.service;
 
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
+import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,8 +24,23 @@ public class MemberServiceImpl implements MemberService {
         // 회원 존재 여부 체크
         memberExists(memberId);
 
-        // 대시보드 정보 조회
-        return memberMapper.findDashboardById(memberId);
+        // 회원 정보 조회
+        MemberDashboardResponse summary = memberMapper.findDashboardInfoById(memberId);
+
+        // 낙찰된 물품 목록 조회
+        List<MemberWonItemResponse> wonItems = memberMapper.findWonItemsById(memberId);
+
+        // 입찰 중인 물품 목록 조회
+        List<MemberBiddingItemResponse> biddingItems = memberMapper.findBiddingItemsById(memberId);
+
+        // 대시보드 응답 DTO
+        return MemberDashboardResponse.builder()
+                .nickname(summary.getNickname())
+                .grade(summary.getGrade())
+                .point(summary.getPoint())
+                .wonItems(wonItems)
+                .biddingItems(biddingItems)
+                .build();
     }
 
     @Override
@@ -38,7 +54,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private void memberExists(Long memberId) {
-        // 회원 단건 조회
+        // 회원 조회
         Member member = memberMapper.findById(memberId);
 
         // 회원 존재하지 않을 시, 예외처리

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -18,29 +18,68 @@
             id = #{id};
     </update>
 
-    <select id="findDashboardById" parameterType="long" resultType="MemberDashboardResponse">
-        SELECT
-            m.point AS point,
-            COALESCE(p.total_purchase_amount, 0) AS totalPurchaseAmount,
-            COALESCE(s.total_sales_amount, 0) AS totalSalesAmount
+    <select id="findDashboardInfoById" parameterType="long" resultType="MemberDashboardResponse">
+        SELECT  m.nickname AS nickname,
+                m.grade AS grade,
+                m.point AS POINT
         FROM member m
-
-        LEFT JOIN (
-            SELECT
-                winner_id,
-                SUM(winner_price) AS total_purchase_amount
-            FROM winner_deal
-            GROUP BY winner_id
-        ) p ON m.id = p.winner_id
-
-        LEFT JOIN (
-            SELECT
-                seller_id,
-                SUM(winner_price) AS total_sales_amount
-            FROM winner_deal
-            GROUP BY seller_id
-        ) s ON m.id = s.seller_id
         WHERE m.id = #{memberId}
+    </select>
+
+    <select id="findWonItemsById" parameterType="long" resultType="MemberWonItemResponse">
+        SELECT  ii.url AS imageUrl,                     -- 상품 대표 이미지 URL
+                ai.name AS itemName,                    -- 상품 이름
+                wd.delivery_status AS deliveryStatus    -- 배송 상태
+        FROM winner_deal wd
+
+        -- 낙찰된 경매 정보 연결
+        INNER JOIN auction a
+        ON wd.auction_id = a.id
+
+        -- 경매에 연결된 상품 정보
+        INNER JOIN auction_item ai
+        ON a.item_id = ai.id
+
+        -- 상품 이미지
+        LEFT JOIN item_image ii
+        ON ii.item_id = ai.id
+        AND ii.`display_order` = 1              -- 대표 이미지 1장만
+
+        WHERE wd.winner_id = #{memberId}
+        AND wd.status IN ('PAID', 'CONFIRMED')  -- 배송 취소 상태 제외
+        ORDER BY wd.created_at DESC             -- 최신순
+        LIMIT 2
+    </select>
+
+    <select id="findBiddingItemsById" parameterType="long" resultType="MemberBiddingItemResponse">
+        SELECT
+            ii.url AS imageUrl,                 -- 상품 대표 이미지 URL
+            ai.name AS itemName,                -- 상품 이름
+            a.vickrey_price AS currentPrice,    -- 차순위 가격
+            mb.myBidPrice AS myBidPrice,        -- 내가 해당 경매에서 입찰한 최고 금액
+            a.end_date AS endDate               -- 경매 종료일
+        FROM (                                  -- 한 경매에 여러 번 입찰 가능, MAX()로 "내 최고 입찰가" 뽑기
+                 SELECT
+                     b.auction_id,
+                     MAX(b.amount) AS myBidPrice
+                 FROM bid b
+                 WHERE b.bidder_id = #{memberId}       -- 경매에 참여한 사용자 id
+                 GROUP BY b.auction_id
+             ) mb
+
+                 INNER JOIN auction a
+                            ON a.id = mb.auction_id
+
+                 INNER JOIN auction_item ai
+                            ON a.item_id = ai.id
+
+                 LEFT JOIN item_image ii
+                           ON ii.item_id = ai.id
+                               AND ii.`display_order` = 1
+
+        WHERE a.status = 'ON_GOING'
+        ORDER BY a.end_date ASC
+        LIMIT 3
     </select>
 
     <select id="findById" parameterType="long" resultType="Member">


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 기존 회원 대시보드 조회 API를 와이어프레임에 맞게 수정
- 응답 구조를 회원 정보 + 낙찰/입찰 목록 형태로 변경
- DTO 추가 및 기존 DTO 수정
- 낙찰된 물품 목록, 입찰 중인 물품 목록 조회 기능 구현
- Mapper 메서드 및 쿼리 추가
- 낙찰/입찰 목록 일부 조회하도록 LIMIT 적용

---

## 📎 관련 이슈

- #79 
