### PR TITLE
feat: 경매 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
@@ -1,6 +1,8 @@
 package com.biddingmate.biddinggo.auction.controller;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.auction.dto.AuctionListRequest;
+import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
 import com.biddingmate.biddinggo.auction.dto.CancelAuctionRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionFromInspectionItemRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
@@ -11,6 +13,7 @@ import com.biddingmate.biddinggo.auction.service.AuctionQueryService;
 import com.biddingmate.biddinggo.auction.service.AuctionService;
 import io.swagger.v3.oas.annotations.Operation;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,16 @@ public class AuctionController {
     private final AuctionApplicationService auctionApplicationService;
     private final AuctionQueryService auctionQueryService;
     private final AuctionService auctionService;
+
+    @GetMapping("")
+    @Operation(summary = "경매 목록 조회", description = "조건에 맞는 경매 목록을 페이징 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<AuctionListResponse>>> getAuctionList(
+            @Valid AuctionListRequest request) {
+
+        PageResponse<AuctionListResponse> result = auctionQueryService.getAuctionList(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "경매 목록 조회 완료", result);
+    }
 
     @GetMapping("/{auctionId}")
     @Operation(summary = "경매 상세 조회", description = "경매 기본 정보, 상품 정보, 카테고리, 이미지 목록을 조회합니다.")

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListRequest.java
@@ -23,7 +23,7 @@ public class AuctionListRequest extends BasePageRequest {
     @Positive(message = "판매자 ID는 1 이상이어야 합니다.")
     private Long sellerId;
 
-    @Schema(description = "카테고리 ID", example = "10", nullable = true)
+    @Schema(description = "카테고리 ID", example = "100", nullable = true)
     @Positive(message = "카테고리 ID는 1 이상이어야 합니다.")
     private Long categoryId;
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListRequest.java
@@ -1,0 +1,29 @@
+package com.biddingmate.biddinggo.auction.dto;
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Schema(description = "경매 목록 조회 요청 DTO")
+public class AuctionListRequest extends BasePageRequest {
+    @Schema(description = "경매 상태", example = "ON_GOING", nullable = true)
+    private String status;
+
+    @Schema(description = "판매자 ID", example = "1", nullable = true)
+    @Positive(message = "판매자 ID는 1 이상이어야 합니다.")
+    private Long sellerId;
+
+    @Schema(description = "카테고리 ID", example = "10", nullable = true)
+    @Positive(message = "카테고리 ID는 1 이상이어야 합니다.")
+    private Long categoryId;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListRequest.java
@@ -16,6 +16,9 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Schema(description = "경매 목록 조회 요청 DTO")
 public class AuctionListRequest extends BasePageRequest {
+    @Schema(description = "정렬 기준", example = "CREATED_AT", allowableValues = {"CREATED_AT", "WISH_COUNT"}, nullable = true)
+    private String sortBy;
+
     @Schema(description = "경매 상태", example = "ON_GOING", nullable = true)
     private String status;
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListResponse.java
@@ -1,0 +1,52 @@
+package com.biddingmate.biddinggo.auction.dto;
+
+import com.biddingmate.biddinggo.auction.model.AuctionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "경매 목록 조회 응답 DTO")
+public class AuctionListResponse {
+    @Schema(description = "경매 ID", example = "1")
+    private Long auctionId;
+
+    @Schema(description = "상품 ID", example = "10")
+    private Long itemId;
+
+    @Schema(description = "브랜드명", example = "Nike")
+    private String brand;
+
+    @Schema(description = "상품명", example = "Air Jordan 1 High")
+    private String name;
+
+    @Schema(description = "경매 상태", example = "ON_GOING")
+    private AuctionStatus status;
+
+    @Schema(description = "시작가", example = "100000")
+    private Long startPrice;
+
+    @Schema(description = "즉시 구매가", example = "180000", nullable = true)
+    private Long buyNowPrice;
+
+    @Schema(description = "입찰 수", example = "0")
+    private Integer bidCount;
+
+    @Schema(description = "경매 종료일시")
+    private LocalDateTime endDate;
+
+    @Schema(description = "대표 이미지 URL", nullable = true)
+    private String representativeImageUrl;
+
+    @Schema(description = "경매 생성일시")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionListResponse.java
@@ -41,6 +41,9 @@ public class AuctionListResponse {
     @Schema(description = "입찰 수", example = "0")
     private Integer bidCount;
 
+    @Schema(description = "관심 수", example = "0")
+    private Integer wishCount;
+
     @Schema(description = "경매 종료일시")
     private LocalDateTime endDate;
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -20,6 +20,7 @@ public interface AuctionMapper extends IMybatisCRUD<Auction> {
                                               @Param("status") AuctionStatus status,
                                               @Param("sellerId") Long sellerId,
                                               @Param("categoryId") Long categoryId,
+                                              @Param("sortBy") String sortBy,
                                               @Param("order") String order);
 
     int countAuctionList(@Param("status") AuctionStatus status,

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -1,17 +1,30 @@
 package com.biddingmate.biddinggo.auction.mapper;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.session.RowBounds;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Mapper
 public interface AuctionMapper extends IMybatisCRUD<Auction> {
     AuctionDetailResponse findDetailById(Long auctionId);
+
+    List<AuctionListResponse> findAuctionList(RowBounds rowBounds,
+                                              @Param("status") AuctionStatus status,
+                                              @Param("sellerId") Long sellerId,
+                                              @Param("categoryId") Long categoryId,
+                                              @Param("order") String order);
+
+    int countAuctionList(@Param("status") AuctionStatus status,
+                         @Param("sellerId") Long sellerId,
+                         @Param("categoryId") Long categoryId);
 
     int updateAuction(Auction auction);
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
@@ -1,12 +1,20 @@
 package com.biddingmate.biddinggo.auction.service;
 
+import com.biddingmate.biddinggo.auction.dto.AuctionListRequest;
+import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 
 /**
  * 경매 조회 전용 서비스.
  * 등록/수정 로직과 분리하여 읽기 책임만 담당한다.
  */
 public interface AuctionQueryService {
+    /**
+     * 조건에 맞는 경매 목록을 페이징 조회한다.
+     */
+    PageResponse<AuctionListResponse> getAuctionList(AuctionListRequest request);
+
     /**
      * 경매 ID를 기준으로 상세 정보를 조회한다.
      */

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -36,9 +36,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         }
 
         AuctionStatus status = parseAuctionStatus(request.getStatus());
-        int page = Math.max(1, request.getPage());
-        int offset = (page - 1) * request.getSize();
-        RowBounds rowBounds = new RowBounds(offset, request.getSize());
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
         String sortOrder = order.toUpperCase();
 
         List<AuctionListResponse> list = auctionMapper.findAuctionList(
@@ -50,7 +48,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         );
         int count = auctionMapper.countAuctionList(status, request.getSellerId(), request.getCategoryId());
 
-        return PageResponse.of(list, page, request.getSize(), count);
+        return PageResponse.of(list, request.getPage(), request.getSize(), count);
     }
 
     private AuctionStatus parseAuctionStatus(String status) {

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -23,6 +23,9 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AuctionQueryServiceImpl implements AuctionQueryService {
+    private static final String DEFAULT_SORT_BY = "CREATED_AT";
+    private static final String SORT_BY_WISH_COUNT = "WISH_COUNT";
+
     private final AuctionMapper auctionMapper;
     private final ItemImageMapper itemImageMapper;
 
@@ -36,6 +39,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         }
 
         AuctionStatus status = parseAuctionStatus(request.getStatus());
+        String sortBy = parseSortBy(request.getSortBy());
         RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
         String sortOrder = order.toUpperCase();
 
@@ -44,6 +48,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
                 status,
                 request.getSellerId(),
                 request.getCategoryId(),
+                sortBy,
                 sortOrder
         );
         int count = auctionMapper.countAuctionList(status, request.getSellerId(), request.getCategoryId());
@@ -61,6 +66,20 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         } catch (IllegalArgumentException exception) {
             throw new CustomException(ErrorType.BAD_REQUEST);
         }
+    }
+
+    private String parseSortBy(String sortBy) {
+        if (sortBy == null || sortBy.isBlank()) {
+            return DEFAULT_SORT_BY;
+        }
+
+        String normalizedSortBy = sortBy.trim().toUpperCase();
+
+        if (!DEFAULT_SORT_BY.equals(normalizedSortBy) && !SORT_BY_WISH_COUNT.equals(normalizedSortBy)) {
+            throw new CustomException(ErrorType.INVALID_SORT_BY);
+        }
+
+        return normalizedSortBy;
     }
 
     @Override

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -36,7 +36,9 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         }
 
         AuctionStatus status = parseAuctionStatus(request.getStatus());
-        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        int page = Math.max(1, request.getPage());
+        int offset = (page - 1) * request.getSize();
+        RowBounds rowBounds = new RowBounds(offset, request.getSize());
         String sortOrder = order.toUpperCase();
 
         List<AuctionListResponse> list = auctionMapper.findAuctionList(
@@ -48,7 +50,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         );
         int count = auctionMapper.countAuctionList(status, request.getSellerId(), request.getCategoryId());
 
-        return PageResponse.of(list, request.getPage(), request.getSize(), count);
+        return PageResponse.of(list, page, request.getSize(), count);
     }
 
     private AuctionStatus parseAuctionStatus(String status) {

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -1,11 +1,16 @@
 package com.biddingmate.biddinggo.auction.service;
 
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.auction.dto.AuctionListRequest;
+import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
+import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.item.mapper.ItemImageMapper;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +25,43 @@ import java.util.List;
 public class AuctionQueryServiceImpl implements AuctionQueryService {
     private final AuctionMapper auctionMapper;
     private final ItemImageMapper itemImageMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AuctionListResponse> getAuctionList(AuctionListRequest request) {
+        String order = request.getOrder();
+
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
+
+        AuctionStatus status = parseAuctionStatus(request.getStatus());
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        String sortOrder = order.toUpperCase();
+
+        List<AuctionListResponse> list = auctionMapper.findAuctionList(
+                rowBounds,
+                status,
+                request.getSellerId(),
+                request.getCategoryId(),
+                sortOrder
+        );
+        int count = auctionMapper.countAuctionList(status, request.getSellerId(), request.getCategoryId());
+
+        return PageResponse.of(list, request.getPage(), request.getSize(), count);
+    }
+
+    private AuctionStatus parseAuctionStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+
+        try {
+            return AuctionStatus.valueOf(status.trim().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new CustomException(ErrorType.BAD_REQUEST);
+        }
+    }
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -17,6 +17,7 @@ public enum ErrorType {
 
     // 페이징 처리
     INVALID_SORT_ORDER("paging-001", "정렬 방향이 존재하질 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SORT_BY("paging-002", "정렬 기준이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 도메인 별 예시
     // auth

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -3,6 +3,20 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.biddingmate.biddinggo.auction.mapper.AuctionMapper">
 
+    <resultMap id="auctionListResultMap" type="com.biddingmate.biddinggo.auction.dto.AuctionListResponse">
+        <id property="auctionId" column="auction_id"/>
+        <result property="itemId" column="item_id"/>
+        <result property="brand" column="brand"/>
+        <result property="name" column="name"/>
+        <result property="status" column="status"/>
+        <result property="startPrice" column="start_price"/>
+        <result property="buyNowPrice" column="buy_now_price"/>
+        <result property="bidCount" column="bid_count"/>
+        <result property="endDate" column="end_date"/>
+        <result property="representativeImageUrl" column="representative_image_url"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
     <resultMap id="auctionDetailResultMap" type="com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse">
         <id property="auctionId" column="auction_id"/>
         <result property="sellerId" column="seller_id"/>
@@ -104,6 +118,56 @@
         INNER JOIN auction_item ai ON a.item_id = ai.id
         INNER JOIN category c3 ON ai.category_id = c3.id
         WHERE a.id = #{auctionId}
+    </select>
+
+    <select id="findAuctionList" parameterType="map" resultMap="auctionListResultMap">
+        SELECT
+            a.id AS auction_id,
+            ai.id AS item_id,
+            ai.brand,
+            ai.name,
+            a.status,
+            a.start_price,
+            a.buy_now_price,
+            a.bid_count,
+            a.end_date,
+            ii.url AS representative_image_url,
+            a.created_at
+        FROM auction a
+        INNER JOIN auction_item ai ON a.item_id = ai.id
+        LEFT JOIN item_image ii ON ii.item_id = ai.id
+            AND ii.display_order = (
+                SELECT MIN(ii2.display_order)
+                FROM item_image ii2
+                WHERE ii2.item_id = ai.id
+            )
+        WHERE 1 = 1
+        <if test="status != null">
+            AND a.status = #{status}
+        </if>
+        <if test="sellerId != null">
+            AND a.seller_id = #{sellerId}
+        </if>
+        <if test="categoryId != null">
+            AND ai.category_id = #{categoryId}
+        </if>
+        ORDER BY a.created_at ${order}
+    </select>
+
+    <select id="countAuctionList" parameterType="map" resultType="_int">
+        SELECT COUNT(*)
+        FROM auction a
+        INNER JOIN auction_item ai ON a.item_id = ai.id
+        WHERE 1 = 1
+        <if test="status != null">
+            AND a.status = #{status}
+        </if>
+        <if test="sellerId != null">
+            AND a.seller_id = #{sellerId}
+        </if>
+        <if test="categoryId != null">
+            AND ai.category_id = #{categoryId}
+        </if>
     </select>
 
     <select id="findById" parameterType="long" resultType="com.biddingmate.biddinggo.auction.model.Auction">

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -12,6 +12,7 @@
         <result property="startPrice" column="start_price"/>
         <result property="buyNowPrice" column="buy_now_price"/>
         <result property="bidCount" column="bid_count"/>
+        <result property="wishCount" column="wish_count"/>
         <result property="endDate" column="end_date"/>
         <result property="representativeImageUrl" column="representative_image_url"/>
         <result property="createdAt" column="created_at"/>
@@ -130,6 +131,7 @@
             a.start_price,
             a.buy_now_price,
             a.bid_count,
+            a.wish_count,
             a.end_date,
             ii.url AS representative_image_url,
             a.created_at
@@ -151,7 +153,11 @@
         <if test="categoryId != null">
             AND ai.category_id = #{categoryId}
         </if>
-        ORDER BY a.created_at ${order}
+        ORDER BY
+        <choose>
+            <when test='sortBy == "WISH_COUNT"'>a.wish_count ${order}, a.created_at DESC</when>
+            <otherwise>a.created_at ${order}</otherwise>
+        </choose>
     </select>
 
     <select id="countAuctionList" parameterType="map" resultType="_int">


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- `GET /api/v1/auctions` 경매 목록 조회 API를 추가.
- 경매 목록 조회용 요청/응답 DTO를 추가.
- `status`, `sellerId`, `categoryId` 조건으로 필터링할 수 있도록 구현.
- `sortBy`, `order` 기반 정렬 기능을 추가하고 `WISH_COUNT` 기준 정렬을 지원.
- 경매 목록 응답값에 `wishCount`를 포함.
- MyBatis 쿼리를 통해 경매 정보, 상품 정보, 대표 이미지 URL을 함께 조회하도록 구성.
- 대표 이미지는 `item_image`의 가장 낮은 `display_order` 기준으로 조회되도록 적용.

---

## 📎 관련 이슈
- closes #72
