### PR TITLE
refactor: 1:1 문의 도메인 권한별 책임 분리 및 경로 재구성

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
+++ b/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
                                 "/index.html",
                                 "/api/v1/payments/**", "/api/v1/files/**",
                                 "/api/v1/auctions/**", "/api/v1/inspections/**",
-                                "/api/v1/direct-inquiries/**",
+                                "/api/v1/direct-inquiries/**", "/api/v1/admins/direct-inquiries/**",
                                 "/api/v1/bidding/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/v1/users/my",

--- a/src/main/java/com/biddingmate/biddinggo/directinquiry/controller/AdminDirectInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/directinquiry/controller/AdminDirectInquiryController.java
@@ -1,0 +1,47 @@
+package com.biddingmate.biddinggo.directinquiry.controller;
+
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.directinquiry.dto.AnswerDirectInquiryRequest;
+import com.biddingmate.biddinggo.directinquiry.dto.AnswerDirectInquiryResponse;
+import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView;
+import com.biddingmate.biddinggo.directinquiry.service.DirectInquiryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admins/direct-inquiries")
+public class AdminDirectInquiryController {
+    private final DirectInquiryService directInquiryService;
+
+    @GetMapping("")
+    // @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<PageResponse<DirectInquiryView>>> findAllDirectInquiry(BasePageRequest request) {
+        PageResponse<DirectInquiryView> result = directInquiryService.findAllDirectInquiry(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "1대1 문의 목록 조회 성공", result);
+    }
+
+    @PatchMapping("/{inquiryId}")
+    // 인증 인가 구현 후 등록 예정
+    // @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<AnswerDirectInquiryResponse>> answerDirectInquiry(@PathVariable Long inquiryId,
+                                                                                        @Valid @RequestBody AnswerDirectInquiryRequest request,
+                                                                                        @RequestParam Long adminId) {
+        AnswerDirectInquiryResponse result = directInquiryService.answerDirectInquiry(inquiryId, request, adminId);
+
+        return ApiResponse.of(HttpStatus.OK, null, "1대1 문의 답변 등록 성공", result);
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/directinquiry/controller/DirectInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/directinquiry/controller/DirectInquiryController.java
@@ -30,7 +30,7 @@ public class DirectInquiryController {
     private final DirectInquiryService directInquiryService;
 
     @PostMapping("")
-    public ResponseEntity<ApiResponse<CreateDirectInquiryResponse>> createAdminInquiry(
+    public ResponseEntity<ApiResponse<CreateDirectInquiryResponse>> createDirectInquiry(
             @RequestBody CreateDirectInquiryRequest request
     ) {
         // 인증 인가 전이므로 writerId를 하드코딩했습니다.
@@ -41,33 +41,12 @@ public class DirectInquiryController {
     }
 
     @GetMapping("")
-    public ResponseEntity<ApiResponse<PageResponse<DirectInquiryView>>> findAdminInquiry(BasePageRequest request,
-                                                                                         @RequestParam boolean isAdmin,
+    public ResponseEntity<ApiResponse<PageResponse<DirectInquiryView>>> findDirectInquiry(BasePageRequest request,
                                                                                          @RequestParam long memberId) {
         // 인증 인가 완료 전이므로 role 검사 및 memberId 전송
         // 추후에 리펙터링 대상입니다.
-        PageResponse<DirectInquiryView> result = directInquiryService.findDirectInquiry(request, isAdmin, memberId);
+        PageResponse<DirectInquiryView> result = directInquiryService.findDirectInquiry(request, memberId);
 
         return ApiResponse.of(HttpStatus.OK, null, "1대1 문의 목록 조회 성공", result);
-    }
-
-    @GetMapping("{inquiryId}")
-    public ResponseEntity<ApiResponse<DirectInquiryViewDetail>> findAdminInquiryDetail(@PathVariable Long inquiryId,
-                                                                                       @RequestParam boolean isAdmin,
-                                                                                       @RequestParam Long memberId) {
-        DirectInquiryViewDetail result = directInquiryService.findDirectInquiryDetail(inquiryId, isAdmin, memberId);
-
-        return ApiResponse.of(HttpStatus.OK, null, "1대1 문의 상세 조회 성공", result);
-    }
-
-    @PatchMapping("/{inquiryId}")
-    // 인증 인가 구현 후 등록 예정
-    // @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<ApiResponse<AnswerDirectInquiryResponse>> answerAdminInquiry(@PathVariable Long inquiryId,
-                                                                                       @Valid @RequestBody AnswerDirectInquiryRequest request,
-                                                                                       @RequestParam Long adminId) {
-        AnswerDirectInquiryResponse result = directInquiryService.answerDirectInquiry(inquiryId, request, adminId);
-
-        return ApiResponse.of(HttpStatus.OK, null, "1대1 문의 답변 등록 성공", result);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/directinquiry/dto/DirectInquiryView.java
+++ b/src/main/java/com/biddingmate/biddinggo/directinquiry/dto/DirectInquiryView.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.directinquiry.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,14 @@ public class DirectInquiryView {
     private Long id;
     private String nickname;
     private String category;
+    private String content;
+
+    private String adminNickname;
     private String answer;
-    private LocalDateTime answeredAt;
-    private LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime answeredAt;  // 답변 등록일
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;   // 문의 작성일
+
 }

--- a/src/main/java/com/biddingmate/biddinggo/directinquiry/mapper/DirectInquiryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/directinquiry/mapper/DirectInquiryMapper.java
@@ -12,14 +12,11 @@ import java.util.List;
 
 @Mapper
 public interface DirectInquiryMapper extends IMybatisCRUD<DirectInquiry> {
-    List<DirectInquiryView> findDirectInquiry(RowBounds rowBounds,
-                                             @Param("order") String sortOrder);
+    List<DirectInquiryView> findAllDirectInquiry(RowBounds rowBounds,
+                                                 @Param("order") String sortOrder);
     List<DirectInquiryView> findDirectInquiryOfMe(RowBounds rowBounds,
                                                  @Param("memberId") long memberId,
                                                  @Param("order") String sortOrder);
     int getDirectInquiryTotal();
     int getDirectInquiryTotalOfMe(@Param("memberId") long memberId);
-
-    DirectInquiryViewDetail findDirectInquiryDetail(Long inquiryId);
-    DirectInquiryViewDetail findDirectInquiryDetailOfMe(Long inquiryId, Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/directinquiry/service/DirectInquiryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/directinquiry/service/DirectInquiryService.java
@@ -1,7 +1,6 @@
 package com.biddingmate.biddinggo.directinquiry.service;
 
 import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView;
-import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryViewDetail;
 import com.biddingmate.biddinggo.directinquiry.dto.AnswerDirectInquiryRequest;
 import com.biddingmate.biddinggo.directinquiry.dto.AnswerDirectInquiryResponse;
 import com.biddingmate.biddinggo.directinquiry.dto.CreateDirectInquiryRequest;
@@ -11,7 +10,9 @@ import com.biddingmate.biddinggo.common.response.PageResponse;
 
 public interface DirectInquiryService {
     CreateDirectInquiryResponse createDirectInquiry(CreateDirectInquiryRequest request);
-    PageResponse<DirectInquiryView> findDirectInquiry(BasePageRequest request, boolean isAdmin, Long memberId);
-    DirectInquiryViewDetail findDirectInquiryDetail(Long inquiryId, boolean isAdmin, Long memberId);
+    PageResponse<DirectInquiryView> findDirectInquiry(BasePageRequest request, Long memberId);
+    PageResponse<DirectInquiryView> findAllDirectInquiry(BasePageRequest request);
     AnswerDirectInquiryResponse answerDirectInquiry(Long inquiryId, AnswerDirectInquiryRequest request, Long adminId);
+
+
 }

--- a/src/main/java/com/biddingmate/biddinggo/directinquiry/service/DirectInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/directinquiry/service/DirectInquiryServiceImpl.java
@@ -1,7 +1,6 @@
 package com.biddingmate.biddinggo.directinquiry.service;
 
 import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView;
-import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryViewDetail;
 import com.biddingmate.biddinggo.directinquiry.dto.AnswerDirectInquiryRequest;
 import com.biddingmate.biddinggo.directinquiry.dto.AnswerDirectInquiryResponse;
 import com.biddingmate.biddinggo.directinquiry.dto.CreateDirectInquiryRequest;
@@ -51,8 +50,8 @@ public class DirectInquiryServiceImpl implements DirectInquiryService {
     }
 
     @Override
-    @Transactional
-    public PageResponse<DirectInquiryView> findDirectInquiry(BasePageRequest request, boolean isAdmin, Long memberId) {
+    @Transactional(readOnly = true)
+    public PageResponse<DirectInquiryView> findAllDirectInquiry(BasePageRequest request) {
         RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
         String order = request.getOrder();
 
@@ -64,34 +63,30 @@ public class DirectInquiryServiceImpl implements DirectInquiryService {
         List<DirectInquiryView> list;
         int count;
 
-        if (isAdmin) {
-            list = directInquiryMapper.findDirectInquiry(rowBounds, sortOrder);
-            count = directInquiryMapper.getDirectInquiryTotal();
-        } else {
-          
-            list = directInquiryMapper.findDirectInquiryOfMe(rowBounds, memberId, sortOrder);
-            count = directInquiryMapper.getDirectInquiryTotalOfMe(memberId);
-        }
+        list = directInquiryMapper.findAllDirectInquiry(rowBounds, sortOrder);
+        count = directInquiryMapper.getDirectInquiryTotal();
 
         return PageResponse.of(list, request.getPage(), request.getSize(), count);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public DirectInquiryViewDetail findDirectInquiryDetail(Long inquiryId, boolean isAdmin, Long memberId) {
-        DirectInquiryViewDetail directInquiryViewDetail;
+    public PageResponse<DirectInquiryView> findDirectInquiry(BasePageRequest request, Long memberId) {
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        String order = request.getOrder();
 
-        if (isAdmin) {
-            directInquiryViewDetail = directInquiryMapper.findDirectInquiryDetail(inquiryId);
-        } else {
-            directInquiryViewDetail = directInquiryMapper.findDirectInquiryDetailOfMe(inquiryId, memberId);
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
         }
+        String sortOrder = order.toUpperCase();
 
-        if (directInquiryViewDetail == null) {
-            throw new CustomException(ErrorType.ADMIN_INQUIRY_NOT_FOUND);
-        }
-
-        return directInquiryViewDetail;
+        List<DirectInquiryView> list;
+        int count;
+      
+        list = directInquiryMapper.findDirectInquiryOfMe(rowBounds, memberId, sortOrder);
+        count = directInquiryMapper.getDirectInquiryTotalOfMe(memberId);
+        
+        return PageResponse.of(list, request.getPage(), request.getSize(), count);
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V8__add_category_to_direct_inquiry.sql
+++ b/src/main/resources/db/migration/V8__add_category_to_direct_inquiry.sql
@@ -1,3 +1,2 @@
 ALTER TABLE direct_inquiry
-    MODIFY COLUMN `admin_id` BIGINT(20) NULL,
-    ADD COLUMN category VARCHAR(20) NOT NULL AFTER admin_id;
+    MODIFY COLUMN category VARCHAR(20) NOT NULL;

--- a/src/main/resources/mapper/direct-inquiry/direct-inquiry-mapper.xml
+++ b/src/main/resources/mapper/direct-inquiry/direct-inquiry-mapper.xml
@@ -22,38 +22,30 @@
                  )
     </insert>
 
-    <!-- resultMap 정의 -->
-    <resultMap id="DirectInquiryViewMap" type="com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView">
-        <id property="id" column="id"/>
-        <result property="nickname" column="nickname"/>
-        <result property="category" column="category"/>
-        <result property="content" column="content"/>
-        <result property="adminNickname" column="admin_nickname"/>
-        <result property="answer" column="answer"/>
-        <result property="answeredAt" column="answered_at"/>
-        <result property="createdAt" column="created_at"/>
-    </resultMap>
-
-    <select id="findDirectInquiry" resultMap="DirectInquiryViewMap">
+    <select id="findAllDirectInquiry" resultType="DirectInquiryView">
         SELECT di.id,
-               m_writer.nickname AS nickname,
+               m_writer.nickname,
                di.category,
-               di.content,         di.answer,
-               m_admin.nickname AS admin_nickname, di.answered_at,
-               di.created_at
+               di.content,
+               m_admin.nickname AS adminNickname,
+               di.answer,
+               di.answered_at AS answeredAt,
+               di.created_at AS createdAt
         FROM direct_inquiry di
         LEFT JOIN member m_writer ON di.writer_id = m_writer.id
-        LEFT JOIN member m_admin ON di.admin_id = m_admin.id ORDER BY di.created_at ${order}
+        LEFT JOIN member m_admin ON di.admin_id = m_admin.id
+        ORDER BY di.created_at ${order}
     </select>
 
-    <select id="findDirectInquiryOfMe" parameterType="map" resultMap="DirectInquiryViewMap">
+    <select id="findDirectInquiryOfMe" parameterType="map" resultType="DirectInquiryView">
         SELECT di.id,
-               m_writer.nickname AS nickname,
+               m_writer.nickname,
                di.category,
-               di.content,         di.answer,
-               m_admin.nickname AS admin_nickname,
-               di.answered_at,
-               di.created_at
+               di.content,
+               m_admin.nickname AS adminNickname,
+               di.answer,
+               di.answered_at AS answeredAt,
+               di.created_at AS createdAt
         FROM direct_inquiry di
         LEFT JOIN member m_writer ON di.writer_id = m_writer.id
         LEFT JOIN member m_admin ON di.admin_id = m_admin.id

--- a/src/main/resources/mapper/direct-inquiry/direct-inquiry-mapper.xml
+++ b/src/main/resources/mapper/direct-inquiry/direct-inquiry-mapper.xml
@@ -23,38 +23,40 @@
     </insert>
 
     <!-- resultMap 정의 -->
-    <resultMap id="DirectInquiryViewMap" type="DirectInquiryView">
+    <resultMap id="DirectInquiryViewMap" type="com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView">
         <id property="id" column="id"/>
         <result property="nickname" column="nickname"/>
         <result property="category" column="category"/>
+        <result property="content" column="content"/>
+        <result property="adminNickname" column="admin_nickname"/>
         <result property="answer" column="answer"/>
         <result property="answeredAt" column="answered_at"/>
         <result property="createdAt" column="created_at"/>
     </resultMap>
 
-    <!-- 관리자 전체 조회 -->
     <select id="findDirectInquiry" resultMap="DirectInquiryViewMap">
         SELECT di.id,
-               m.nickname,
+               m_writer.nickname AS nickname,
                di.category,
-               di.answer,
-               di.answered_at,
+               di.content,         di.answer,
+               m_admin.nickname AS admin_nickname, di.answered_at,
                di.created_at
         FROM direct_inquiry di
-        LEFT JOIN member m ON di.writer_id = m.id
-        ORDER BY di.created_at ${order}
+        LEFT JOIN member m_writer ON di.writer_id = m_writer.id
+        LEFT JOIN member m_admin ON di.admin_id = m_admin.id ORDER BY di.created_at ${order}
     </select>
 
-    <!-- 사용자 본인 조회 -->
     <select id="findDirectInquiryOfMe" parameterType="map" resultMap="DirectInquiryViewMap">
         SELECT di.id,
-               m.nickname,
+               m_writer.nickname AS nickname,
                di.category,
-               di.answer,
+               di.content,         di.answer,
+               m_admin.nickname AS admin_nickname,
                di.answered_at,
                di.created_at
         FROM direct_inquiry di
-        LEFT JOIN member m ON di.writer_id = m.id
+        LEFT JOIN member m_writer ON di.writer_id = m_writer.id
+        LEFT JOIN member m_admin ON di.admin_id = m_admin.id
         WHERE di.writer_id = #{memberId}
         ORDER BY di.created_at ${order}
     </select>
@@ -69,39 +71,6 @@
         SELECT COUNT(*)
         FROM direct_inquiry
         WHERE writer_id = #{memberId}
-    </select>
-
-    <!-- 관리자 문의글 상세 조회 -->
-    <select id="findDirectInquiryDetdil" parameterType="map" resultType="DirectInquiryViewDetail">
-        SELECT di.id,
-               m.nickname AS writerNickname,
-               di.category,
-               di.content,
-               di.answer,
-               am.nickname AS adminNickname,
-               di.answered_at AS answeredAt,
-               di.created_at AS createdAt
-        FROM direct_inquiry di
-        JOIN member m ON di.writer_id = m.id
-        LEFT JOIN member am ON di.admin_id = am.id
-        WHERE di.id = #{inquiryId}
-    </select>
-
-    <!-- 사용자 문의글 상세 조회 -->
-    <select id="findDirectInquiryDetailOfMe" parameterType="map" resultType="DirectInquiryViewDetail">
-        SELECT di.id,
-               m.nickname AS writerNickname,
-               di.category,
-               di.content,
-               di.answer,
-               am.nickname AS adminNickname,
-               di.answered_at AS answeredAt,
-               di.created_at AS createdAt
-        FROM direct_inquiry di
-        JOIN member m ON di.writer_id = m.id
-        LEFT JOIN member am ON di.admin_id = am.id
-        WHERE di.id = #{inquiryId}
-          AND di.writer_id = #{memberId}
     </select>
 
     <!-- 문의 답변 -->


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [x] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 컨트롤러 분리: 사용자/관리자 API 경로 분리 (/api/v1/admins 추가) 및 isAdmin 파라미터 제거
- API 통합: 상세 조회 API를 삭제하고, 목록 조회 시 상세 내용(본문, 답변 등)을 포함하도록 변경
- DTO & Mapper 수정: DirectInquiryView에 상세 필드 추가 및 MyBatis 조인 쿼리 보강

---

## 📎 관련 이슈
- #85 
