### PR TITLE
feat: 경매 문의글 조회 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
@@ -39,7 +39,7 @@ public class AuctionInquiryController {
                 auctionInquiryService.createInquiry(
                         request.getAuctionId(),
                         writerId,
-                        request.getContent()
+                        request
                 );
 
         return ApiResponse.of(

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/controller/AuctionInquiryController.java
@@ -2,17 +2,25 @@ package com.biddingmate.biddinggo.auctioninquiry.controller;
 
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryResponse;
+import com.biddingmate.biddinggo.auctioninquiry.dto.AuctionInquiryView;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.service.AuctionInquiryService;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auction Inquiry", description = "경매 문의 API")
 @RestController
@@ -66,6 +74,23 @@ public class AuctionInquiryController {
                 HttpStatus.OK,
                 null,
                 "경매 문의 답변 등록 성공",
+                result
+        );
+    }
+
+    @Operation(summary = "경매 문의 목록 조회", description = "해당 경매의 문의글을 페이지 단위로 조회합니다.")
+    @GetMapping("/auctions/{auctionId}/inquiries")
+    public ResponseEntity<ApiResponse<PageResponse<AuctionInquiryView>>> getInquiryList(
+            @PathVariable Long auctionId,
+            BasePageRequest request
+    ) {
+        PageResponse<AuctionInquiryView> result =
+                auctionInquiryService.getInquiriesByAuctionId(auctionId, request);
+
+        return ApiResponse.of(
+                HttpStatus.OK,
+                null,
+                "경매 문의 목록 조회 성공",
                 result
         );
     }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/AuctionInquiryView.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/AuctionInquiryView.java
@@ -1,0 +1,37 @@
+package com.biddingmate.biddinggo.auctioninquiry.dto;
+
+import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiryStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuctionInquiryView {
+    private Long id;
+    private String title;
+    private String content;
+    private String writerName;
+    private String answer;
+    private AuctionInquiryStatus status;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    // 닉네임 마스킹 로직
+    public void maskWriterName() {
+        if (this.writerName != null && this.writerName.length() >= 3) {
+            this.writerName = this.writerName.substring(0, 3) + "***";
+        } else if (this.writerName != null && !this.writerName.isEmpty()) {
+            this.writerName = this.writerName + "***";
+        } else {
+            this.writerName = "익명***";
+        }
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryRequest.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.auctioninquiry.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,7 +15,12 @@ public class CreateAuctionInquiryRequest {
     @NotNull(message = "경매 ID는 필수입니다.")
     private Long auctionId;
 
-    @Schema(description = "문의 내용", example = "상품 상태가 어떤가요?", required = true)
+    @Schema(description = "문의 제목", example = "상품 상태가 어떤가요?", required = true) // 추가
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")
+    private String title;
+
+    @Schema(description = "문의 내용", example = "직거래 가능한가요?", required = true)
     @NotBlank(message = "문의 내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/dto/CreateAuctionInquiryResponse.java
@@ -22,6 +22,8 @@ public class CreateAuctionInquiryResponse {
     @Schema(description = "작성자 ID", example = "1")
     private Long writerId;
 
+    private String title;
+
     @Schema(description = "문의 내용", example = "상품 상태가 어떤가요?")
     private String content;
 

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/mapper/AuctionInquiryMapper.java
@@ -1,8 +1,13 @@
 package com.biddingmate.biddinggo.auctioninquiry.mapper;
 
+import com.biddingmate.biddinggo.auctioninquiry.dto.AuctionInquiryView;
 import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -11,4 +16,8 @@ public interface AuctionInquiryMapper extends IMybatisCRUD<AuctionInquiry> {
     Optional<AuctionInquiry> findInquiryById(Long id);
 
     int updateAnswer(AuctionInquiry inquiry);
+
+    List<AuctionInquiryView> selectInquiryList(RowBounds rowBounds, @Param("auctionId") Long auctionId);
+
+    int selectInquiryCount(@Param("auctionId") Long auctionId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/model/AuctionInquiry.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/model/AuctionInquiry.java
@@ -14,7 +14,7 @@ public class AuctionInquiry {
     private Long auctionId;
     private Long writerId;
     private Long answererId;
-
+    private String title;
     private String content;
     private String answer;
 

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
@@ -2,11 +2,16 @@ package com.biddingmate.biddinggo.auctioninquiry.service;
 
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryResponse;
+import com.biddingmate.biddinggo.auctioninquiry.dto.AuctionInquiryView;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 
 public interface AuctionInquiryService {
 
     CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, CreateAuctionInquiryRequest request);
+
     AnswerAuctionInquiryResponse registerAnswer(Long inquiryId, Long sellerId, AnswerAuctionInquiryRequest request);
+
+    PageResponse<AuctionInquiryView> getInquiriesByAuctionId(Long auctionId, com.biddingmate.biddinggo.common.request.BasePageRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryService.java
@@ -2,10 +2,11 @@ package com.biddingmate.biddinggo.auctioninquiry.service;
 
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryResponse;
+import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 
 public interface AuctionInquiryService {
 
-    CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content);
+    CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, CreateAuctionInquiryRequest request);
     AnswerAuctionInquiryResponse registerAnswer(Long inquiryId, Long sellerId, AnswerAuctionInquiryRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -4,6 +4,7 @@ import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryResponse;
+import com.biddingmate.biddinggo.auctioninquiry.dto.AuctionInquiryView;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.mapper.AuctionInquiryMapper;
@@ -11,11 +12,15 @@ import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
 import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiryStatus;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,10 +34,7 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
     public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, CreateAuctionInquiryRequest request) {
 
         // 경매 존재 여부 검증
-        Auction auction = auctionMapper.findById(auctionId);
-        if (auction == null) {
-            throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
-        }
+        Auction auction = validateAndGetAuction(auctionId);
 
         // 본인 경매 문의 제한
         if (auction.getSellerId().equals(writerId)) {
@@ -99,5 +101,40 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
                 .answer(inquiry.getAnswer())
                 .answeredAt(now)
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AuctionInquiryView> getInquiriesByAuctionId(Long auctionId, BasePageRequest request) {
+
+        // 공통 메서드를 통한 경매 존재 여부 확인
+        validateAndGetAuction(auctionId);
+
+        // 페이지 번호 검증
+        if (request.getPage() < 1) {
+            throw new CustomException(ErrorType.BAD_REQUEST);
+        }
+
+        // RowBounds 생성
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+
+        // DB 조회
+        List<AuctionInquiryView> list = auctionInquiryMapper.selectInquiryList(rowBounds, auctionId);
+        int totalCount = auctionInquiryMapper.selectInquiryCount(auctionId);
+
+        // 닉네임 마스킹 로직
+        list.forEach(AuctionInquiryView::maskWriterName);
+
+        return PageResponse.of(list, request.getPage(), request.getSize(), totalCount);
+    }
+
+    // 경매 존재 여부 확인 로직 공통 메서드
+
+    private Auction validateAndGetAuction(Long auctionId) {
+        Auction auction = auctionMapper.findById(auctionId);
+        if (auction == null) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
+        }
+        return auction;
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auctioninquiry/service/AuctionInquiryServiceImpl.java
@@ -4,6 +4,7 @@ import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.AnswerAuctionInquiryResponse;
+import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryRequest;
 import com.biddingmate.biddinggo.auctioninquiry.dto.CreateAuctionInquiryResponse;
 import com.biddingmate.biddinggo.auctioninquiry.mapper.AuctionInquiryMapper;
 import com.biddingmate.biddinggo.auctioninquiry.model.AuctionInquiry;
@@ -25,7 +26,7 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
 
     @Override
     @Transactional
-    public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, String content) {
+    public CreateAuctionInquiryResponse createInquiry(Long auctionId, Long writerId, CreateAuctionInquiryRequest request) {
 
         // 경매 존재 여부 검증
         Auction auction = auctionMapper.findById(auctionId);
@@ -42,7 +43,8 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
                 .auctionId(auctionId)
                 .writerId(writerId)
                 .answererId(auction.getSellerId())
-                .content(content)
+                .title(request.getTitle())
+                .content(request.getContent())
                 .status(AuctionInquiryStatus.PENDING)
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -57,6 +59,7 @@ public class AuctionInquiryServiceImpl implements AuctionInquiryService {
                 .id(inquiry.getId())
                 .auctionId(inquiry.getAuctionId())
                 .writerId(inquiry.getWriterId())
+                .title(inquiry.getTitle())
                 .content(inquiry.getContent())
                 .createdAt(inquiry.getCreatedAt())
                 .build();

--- a/src/main/resources/db/migration/V9__add_title_to_auction_inquiry.sql
+++ b/src/main/resources/db/migration/V9__add_title_to_auction_inquiry.sql
@@ -1,0 +1,9 @@
+ALTER TABLE auction_inquiry
+    ADD COLUMN title VARCHAR(50) AFTER writer_id;
+
+UPDATE auction_inquiry
+SET title = '기존 문의글입니다'
+WHERE title IS NULL;
+
+ALTER TABLE auction_inquiry
+    MODIFY COLUMN title VARCHAR(50) NOT NULL;

--- a/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
+++ b/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
@@ -10,12 +10,14 @@
             auction_id,
             writer_id,
             answerer_id,
+            title,
             content,
             created_at
         ) VALUES (
                      #{auctionId},
                      #{writerId},
                      #{answererId},
+                     #{title},
                      #{content},
                      #{createdAt}
                  )
@@ -27,6 +29,7 @@
             auction_id AS auctionId,
             writer_id AS writerId,
             answerer_id AS answererId,
+            title,
             content,
             answer,
             status,

--- a/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
+++ b/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
@@ -46,4 +46,25 @@
             status      = #{status}
         WHERE id = #{id}
           AND answer IS NULL </update>
+
+    <select id="selectInquiryList" resultType="AuctionInquiryView">
+        SELECT
+            ai.id,
+            ai.title,
+            ai.content,
+            m.nickname AS writerName,
+            ai.answer,
+            ai.status,
+            ai.created_at AS createdAt
+        FROM auction_inquiry ai
+                 LEFT JOIN member m ON ai.writer_id = m.id
+        WHERE ai.auction_id = #{auctionId}
+        ORDER BY ai.created_at DESC
+    </select>
+
+    <select id="selectInquiryCount" resultType="int">
+        SELECT COUNT(*)
+        FROM auction_inquiry
+        WHERE auction_id = #{auctionId}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 목록 조회 API: 특정 경매에 달린 문의글을 불러오는 기능을 구현했습니다.
- 데이터 정합성 검증: 문의 조회 전 해당 경매가 실제로 존재하는지 확인하는 공통 검증 로직을 추가했습니다.
- 닉네임 마스킹 로직: AuctionInquiryView DTO 내에 작성자의 이름을 보호하기 위한 maskWriterName() 메서드를 구현했습니다.
---

## 📎 관련 이슈
close #89 
