### PR TITLE
feat: 회원 프로필 수정 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -83,8 +83,11 @@ public enum ErrorType {
     AUCTION_INQUIRY_NOT_FOUND("auction-inquiry-004", "해당 경매 문의가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     AUCTION_INQUIRY_ALREADY_ANSWERED("auction-inquiry-005", "이미 답변이 등록된 문의입니다.", HttpStatus.CONFLICT),
     AUCTION_INQUIRY_UPDATE_FAIL("auction-inquiry-006", "경매 문의 답변 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+
     // 회원 정보
     MEMBER_NOT_FOUND("member-001", "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND),
+    INVALID_NICKNAME_CHANGE_PERIOD("member-002", "닉네임은 30일 이후에 변경할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATED_NICKNAME("member-003", "이미 사용 중인 닉네임입니다.", HttpStatus.BAD_REQUEST),
 
     // 입찰
     BID_SAVE_FAILED("bid-001", "입찰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -3,11 +3,14 @@ package com.biddingmate.biddinggo.member.controller;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
+import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +32,14 @@ public class MemberController {
     public ResponseEntity<ApiResponse<MemberProfileResponse>> getProfile(@RequestParam Long memberId) {
         MemberProfileResponse result = memberService.getMyProfile(memberId);
         return ApiResponse.of(HttpStatus.OK, null, "회원 프로필 조회 성공", result);
+    }
+
+    @PatchMapping("/me/profile")
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> updateMyProfile(
+            @RequestParam Long memberId,
+            @RequestBody MemberProfileUpdateRequest request
+            ) {
+        MemberProfileResponse result = memberService.updateMyProfile(memberId, request);
+        return ApiResponse.of(HttpStatus.OK, null, "회원 프로필 수정 성공", result);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberProfileUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberProfileUpdateRequest {
+    private String nickname;
+    private String imageUrl;
+    private String bankCode;
+    private String bankAccount;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -4,6 +4,7 @@ import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
+import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import org.apache.ibatis.annotations.Mapper;
@@ -29,4 +30,9 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
 
     // 입찰 중 물품 목록
     List<MemberBiddingItemResponse> findBiddingItemsById(@Param("memberId") Long memberId);
+
+    void updateProfile(@Param("memberId") Long memberId, @Param("request") MemberProfileUpdateRequest request);
+
+    // 수정할 닉네임이 사용 중 인지 확인
+    int countByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/model/Member.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/model/Member.java
@@ -25,7 +25,7 @@ public class Member {
     private String grade;
     private String role;
     private String status;
-    private String lastChangeNick;
+    private LocalDateTime lastChangeNick;
     private LocalDateTime createdAt;
 
     public void update(String name, String email) {

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -2,9 +2,12 @@ package com.biddingmate.biddinggo.member.service;
 
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
+import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 
 public interface MemberService {
     MemberDashboardResponse getMyDashboard(Long id);
 
     MemberProfileResponse getMyProfile(Long memberId);
+
+    MemberProfileResponse updateMyProfile(Long memberId, MemberProfileUpdateRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -5,13 +5,16 @@ import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
+import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -53,8 +56,32 @@ public class MemberServiceImpl implements MemberService {
         return memberMapper.findProfileById(memberId);
     }
 
+    @Override
+    public MemberProfileResponse updateMyProfile(Long memberId, MemberProfileUpdateRequest request) {
+
+        // 회원 존재 여부 확인
+        Member member = getMember(memberId);
+
+        // 닉네임 변경 요청 시
+        if (isNicknameChanged(member, request)) {
+
+            // 마지막 닉네임 변경일 기준 30일 지났는지 체크
+            validateNickNameChangePeriod(member);
+
+            // 닉네임 중복 체크
+            validateDuplicateNickname(request.getNickname());
+        }
+
+        // 프로필 수정
+        memberMapper.updateProfile(memberId, request);
+
+        // 수정된 프로필 정보 반환
+        return memberMapper.findProfileById(memberId);
+    }
+
+    // 회원 존재 여부 확인
     private void memberExists(Long memberId) {
-        // 회원 조회
+
         Member member = memberMapper.findById(memberId);
 
         // 회원 존재하지 않을 시, 예외처리
@@ -62,4 +89,46 @@ public class MemberServiceImpl implements MemberService {
             throw new CustomException(ErrorType.MEMBER_NOT_FOUND);
         }
     }
+
+    // 닉네임 변경 요청 확인 > 요청 닉네임이 존재하고, 공백이 아니고, 기존 닉네임과 다르면 true
+    private boolean isNicknameChanged(Member member, MemberProfileUpdateRequest request) {
+        return request.getNickname() != null
+                && !request.getNickname().isBlank()
+                && !Objects.equals(member.getNickname(), request.getNickname());
+    }
+
+    // 닉네임 변경 주기 확인 > lastChangeNick이 null이면 최초 변경이므로
+    // 마지막 변경일로부터 30일이 지나지 않았으면 예외 발생
+    private void validateNickNameChangePeriod(Member member) {
+        if (member.getLastChangeNick() == null) {
+            return;
+        }
+
+        LocalDateTime changeableDate = member.getLastChangeNick().plusDays(30);
+
+        if (LocalDateTime.now().isBefore(changeableDate)) {
+            throw new CustomException(ErrorType.INVALID_NICKNAME_CHANGE_PERIOD);
+        }
+    }
+
+    // 동일한 닉네임이 존재하면 예외 발생
+    private void validateDuplicateNickname(String nickname) {
+        int count = memberMapper.countByNickname(nickname);
+
+        if (count > 0) {
+            throw new CustomException(ErrorType.DUPLICATED_NICKNAME);
+        }
+    }
+
+    // 회원 조회
+    private Member getMember(Long memberId) {
+        Member member = memberMapper.findById(memberId);
+
+        if (member == null) {
+            throw new CustomException(ErrorType.MEMBER_NOT_FOUND);
+        }
+
+        return member;
+    }
+
 }

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -129,4 +129,30 @@
                  LEFT JOIN address a ON m.id = a.member_id
         WHERE m.id = #{memberId}
     </select>
+
+    <select id="countByNickname" parameterType="string" resultType="int">
+        SELECT COUNT(*)
+        FROM member
+        WHERE nickname =#{nickname}
+    </select>
+
+    <update id="updateProfile" parameterType="map">
+        UPDATE member
+        <set>
+            <if test="request.nickname != null and request.nickname != ''">
+                nickname = #{request.nickname},
+                last_change_nick = NOW(),
+            </if>
+            <if test="request.imageUrl != null and request.imageUrl != ''">
+                image_url = #{request.imageUrl},
+            </if>
+            <if test="request.bankCode != null and request.bankCode != ''">
+                bank_code = #{request.bankCode},
+            </if>
+            <if test="request.bankAccount != null and request.bankAccount != ''">
+                bank_account = #{request.bankAccount},
+            </if>
+        </set>
+        WHERE id = #{memberId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 회원 프로필 수정 API 구현
- 닉네임 변경 시 30일 제한 검증 로직 추가
- 닉네임 중복 검사 로직 추가
- 프로필 수정 요청 DTO
- 회원 프로필 수정 관련 Mapper 및 쿼리 추가

---

## 📎 관련 이슈
닫고 싶은 이슈가 있다면 아래에 키워드로 연결하세요.

- close #52 
