### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -93,6 +93,7 @@ public enum ErrorType {
     MEMBER_NOT_FOUND("member-001", "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND),
     INVALID_NICKNAME_CHANGE_PERIOD("member-002", "닉네임은 30일 이후에 변경할 수 있습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATED_NICKNAME("member-003", "이미 사용 중인 닉네임입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_DELETED_MEMBER("member-004", "탈퇴한 회원입니다.", HttpStatus.BAD_REQUEST),
 
     // 입찰
     BID_SAVE_FAILED("bid-001", "입찰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.biddingmate.biddinggo.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +42,11 @@ public class MemberController {
             ) {
         MemberProfileResponse result = memberService.updateMyProfile(memberId, request);
         return ApiResponse.of(HttpStatus.OK, null, "회원 프로필 수정 성공", result);
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(@RequestParam Long memberId) {
+        memberService.deleteMyAccount(memberId);
+        return ApiResponse.of(HttpStatus.OK, null, "회원 탈퇴 성공", null);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -35,4 +35,7 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
 
     // 수정할 닉네임이 사용 중 인지 확인
     int countByNickname(@Param("nickname") String nickname);
+
+    // member status를 DELETED로 변경
+    void deleteMember(Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -10,4 +10,6 @@ public interface MemberService {
     MemberProfileResponse getMyProfile(Long memberId);
 
     MemberProfileResponse updateMyProfile(Long memberId, MemberProfileUpdateRequest request);
+
+    void deleteMyAccount(Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -79,6 +79,21 @@ public class MemberServiceImpl implements MemberService {
         return memberMapper.findProfileById(memberId);
     }
 
+    @Override
+    public void deleteMyAccount(Long memberId) {
+
+        // 회원 존재 여부 확인
+        Member member = getMember(memberId);
+
+        // 이미 탈퇴한 회원이라면 예외 처리
+        if ("DELETED".equals(member.getStatus())) {
+            throw new CustomException(ErrorType.ALREADY_DELETED_MEMBER);
+        }
+
+        // 탈퇴 처리 (soft delete)
+        memberMapper.deleteMember(memberId);
+    }
+
     // 회원 존재 여부 확인
     private void memberExists(Long memberId) {
 

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -155,4 +155,10 @@
         </set>
         WHERE id = #{memberId}
     </update>
+
+    <update id="deleteMember" parameterType="long">
+        UPDATE member
+        SET status = 'DELETED'
+        WHERE id = #{memberId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 회원 탈퇴 API 추가
- 회원 탈퇴 시 물리 삭제가 아닌 status = DELETED로 변경하도록 구현
- 회원 탈퇴용 Service, Mapper, XML 쿼리 추가
- 이미 탈퇴한 회원 요청에 대한 예외 처리 추가

---

## 📎 관련 이슈

- close #95 
