### PR TITLE
feat: 마이페이지 포인트 잔액 및 변동 내역 조회 API

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/request/BasePageRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/request/BasePageRequest.java
@@ -26,31 +26,28 @@ import org.springframework.data.domain.Pageable;
 @SuperBuilder
 @Schema(description = "공용 페이징 요청 DTO")
 public class BasePageRequest {
-    private static final int DEFAULT_PAGE = 0;
-    private static final int DEFAULT_SIZE = 10;
     private static final int MAX_SIZE = 100;
-    private static final String DEFAULT_ORDER = "ASC";
 
-    @Schema(description = "0부터 시작하는 페이지 번호", example = "0", defaultValue = "0")
+    @Schema(description = "1부터 시작하는 페이지 번호", example = "1", defaultValue = "1")
     @NotNull(message = "페이지 번호는 필수입니다.")
-    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
-    protected Integer page;
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
+    @Builder.Default
+    protected Integer page = 1;
 
     @Schema(description = "페이지 크기", example = "20", defaultValue = "20")
     @NotNull(message = "페이지 크기는 필수입니다.")
     @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
     @Max(value = MAX_SIZE, message = "페이지 크기는 100 이하여야 합니다.")
-    protected Integer size;
+    @Builder.Default
+    protected Integer size = 10;
 
     @Schema(description = "정렬 방향", example = "ASC", defaultValue = "ASC")
-    protected String order;
+    @NotNull(message = "정렬 방향은 필수입니다.")
+    @Builder.Default
+    protected String order = "ASC";
 
     public int getOffset() {
         // page가 1부터 시작한다고 가정할 경우
-        return (page > 0) ? (page - 1) * size : 0;
-    }
-
-    public int getLimit() {
-        return size;
+        return (page - 1) * size;
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
+++ b/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
                                 "/api/v1/payments/**", "/api/v1/files/**", "/api/v1/addresses/**",
                                 "/api/v1/auctions/**", "/api/v1/inspections/**",
                                 "/api/v1/direct-inquiries/**", "/api/v1/admins/direct-inquiries/**",
-                                "/api/v1/bidding/**",
+                                "/api/v1/bidding/**","/api/v1/points/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/v1/users/my",
                                 "/api/v1/auction/**",

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -12,4 +12,6 @@ public interface MemberService {
     MemberProfileResponse updateMyProfile(Long memberId, MemberProfileUpdateRequest request);
 
     void deleteMyAccount(Long memberId);
+
+    long getCurrentPoint(Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -92,6 +93,12 @@ public class MemberServiceImpl implements MemberService {
 
         // 탈퇴 처리 (soft delete)
         memberMapper.deleteMember(memberId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long getCurrentPoint(Long memberId) {
+        return getMember(memberId).getPoint();
     }
 
     // 회원 존재 여부 확인

--- a/src/main/java/com/biddingmate/biddinggo/point/controller/PointController.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/controller/PointController.java
@@ -1,12 +1,28 @@
 package com.biddingmate.biddinggo.point.controller;
 
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.point.dto.MyPointResponse;
+import com.biddingmate.biddinggo.point.service.PointService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/points")
 @RequiredArgsConstructor
 public class PointController {
+    private final PointService pointService;
 
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MyPointResponse>> findMyPointList(BasePageRequest request,
+                                                                        @RequestParam Long memberId) {
+        MyPointResponse result = pointService.findMyPointList(request, memberId);
+
+        return ApiResponse.of(HttpStatus.OK, null, "마이페이지 포인트 내역 조회에 성공했습니다.", result);
+    }
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/dto/MyPointResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/dto/MyPointResponse.java
@@ -1,0 +1,15 @@
+package com.biddingmate.biddinggo.point.dto;
+
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.point.model.PointHistory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MyPointResponse {
+    private long currentPoint;
+    private PageResponse<PointHistoryDto> histroies;
+}

--- a/src/main/java/com/biddingmate/biddinggo/point/dto/PointHistoryDto.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/dto/PointHistoryDto.java
@@ -1,0 +1,17 @@
+package com.biddingmate.biddinggo.point.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PointHistoryDto {
+    private Long id;
+    private String type;
+    private long amount;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/point/mapper/PointHistoryMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/mapper/PointHistoryMapper.java
@@ -1,10 +1,18 @@
 package com.biddingmate.biddinggo.point.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.point.dto.PointHistoryDto;
 import com.biddingmate.biddinggo.point.model.PointHistory;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
 
 @Mapper
 public interface PointHistoryMapper extends IMybatisCRUD<PointHistory> {
-
+    List<PointHistoryDto> findByMemberId(RowBounds rowBounds,
+                                         @Param("order") String sortOrder,
+                                         @Param("memberId") Long memberId);
+    int countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/service/PointService.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/service/PointService.java
@@ -1,5 +1,8 @@
 package com.biddingmate.biddinggo.point.service;
 
-public interface PointService {
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.point.dto.MyPointResponse;
 
+public interface PointService {
+    MyPointResponse findMyPointList(BasePageRequest request, Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/service/PointServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/service/PointServiceImpl.java
@@ -1,5 +1,51 @@
 package com.biddingmate.biddinggo.point.service;
 
-public class PointServiceImpl implements PointService {
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView;
+import com.biddingmate.biddinggo.member.service.MemberService;
+import com.biddingmate.biddinggo.point.dto.MyPointResponse;
+import com.biddingmate.biddinggo.point.dto.PointHistoryDto;
+import com.biddingmate.biddinggo.point.mapper.PointHistoryMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PointServiceImpl implements PointService {
+    private final MemberService memberService;
+    private final PointHistoryMapper pointHistoryMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MyPointResponse findMyPointList(BasePageRequest request, Long memberId) {
+        long currentPoint = memberService.getCurrentPoint(memberId);
+
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        String order = request.getOrder();
+
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
+        String sortOrder = order.toUpperCase();
+
+        List<PointHistoryDto> list;
+        int count;
+
+        list = pointHistoryMapper.findByMemberId(rowBounds, sortOrder, memberId);
+        count = pointHistoryMapper.countByMemberId(memberId);
+
+        PageResponse<PointHistoryDto> pointhistory = PageResponse.of(list, request.getPage(), request.getSize(), count);
+
+        return MyPointResponse.builder()
+                .currentPoint(currentPoint)
+                .histroies(pointhistory)
+                .build();
+    }
 }

--- a/src/main/resources/db/migration/V10__update_address_detail_address_nullable.sql
+++ b/src/main/resources/db/migration/V10__update_address_detail_address_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE address
+    MODIFY COLUMN detail_address varchar(255) NULL;

--- a/src/main/resources/mapper/point/point-history-mapper.xml
+++ b/src/main/resources/mapper/point/point-history-mapper.xml
@@ -22,4 +22,22 @@
                );
     </insert>
 
+    <!-- 회원별 포인트 히스토리 조회 -->
+    <select id="findByMemberId" parameterType="map" resultType="PointHistoryDto">
+        SELECT id,
+               type,
+               amount,
+               created_at
+        FROM point_history
+        WHERE member_id = #{memberId}
+        ORDER BY created_at ${order}
+    </select>
+
+    <!-- 회원별 총 건수 조회 -->
+    <select id="countByMemberId" parameterType="long" resultType="int">
+        SELECT COUNT(*)
+        FROM point_history
+        WHERE member_id = #{memberId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 로그인한 회원의 현재 포인트 조회 기능 구현 (MemberService 활용)
- 회원별 포인트 변동 내역 조회 기능 구현 (PointHistoryMapper 활용, 페이징 적용, 최신순 정렬)
- PointHistoryDto를 사용하여 엔티티 노출 없이 API 응답 반환
- MyPointResponse DTO로 현재 포인트 + 변동 내역을 BFF 형태로 통합
- 서비스/Mapper/DTO 계층에서 read-only 트랜잭션 적용 및 예외 처리 (회원 존재하지 않을 시 예외)
- flyway V__10 파일 추가 (address 테이블의 detail_address 컬럼을 nullable 로 수정)

---

## 📎 관련 이슈
- #102