### PR TITLE
feat: 회원 구매내역 조회 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -1,10 +1,14 @@
 package com.biddingmate.biddinggo.member.controller;
 
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
+import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
 import com.biddingmate.biddinggo.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,5 +52,17 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Void>> deleteAccount(@RequestParam Long memberId) {
         memberService.deleteMyAccount(memberId);
         return ApiResponse.of(HttpStatus.OK, null, "회원 탈퇴 성공", null);
+    }
+
+    @GetMapping("/me/purchases")
+    public ResponseEntity<ApiResponse<PageResponse<MemberPurchaseItemResponse>>> getPurchases(
+            @RequestParam Long memberId,
+            @Valid BasePageRequest pageRequest
+            ) {
+
+        PageResponse<MemberPurchaseItemResponse> result = memberService.getMyPurchases(memberId, pageRequest);
+
+        return ApiResponse.of(HttpStatus.OK, null, "구매 내역 조회 성공", result);
+
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberPurchaseItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberPurchaseItemResponse.java
@@ -1,0 +1,30 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberPurchaseItemResponse {
+
+    // 상품명
+    private String itemName;
+
+    // 판매자 이름
+    private String sellerName;
+
+    // 구매 금액 (낙찰가)
+    private Long price;
+
+    // 거래 완료 날짜
+    private LocalDateTime completedAt;
+
+    // 배송 상태
+    private String deliveryStatus;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -1,10 +1,12 @@
 package com.biddingmate.biddinggo.member.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
+import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import org.apache.ibatis.annotations.Mapper;
@@ -38,4 +40,11 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
 
     // member status를 DELETED로 변경
     void deleteMember(Long memberId);
+
+    // 구매내역 목록
+    List<MemberPurchaseItemResponse> findPurchasesByMemberId(
+            @Param("memberId") Long memberId, @Param("pageRequest") BasePageRequest pageRequest);
+
+    // 총 구매 개수 조회
+    long countPurchasesByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -1,8 +1,12 @@
 package com.biddingmate.biddinggo.member.service;
 
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
+import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import jakarta.validation.Valid;
 
 public interface MemberService {
     MemberDashboardResponse getMyDashboard(Long id);
@@ -12,4 +16,6 @@ public interface MemberService {
     MemberProfileResponse updateMyProfile(Long memberId, MemberProfileUpdateRequest request);
 
     void deleteMyAccount(Long memberId);
+
+    PageResponse<MemberPurchaseItemResponse> getMyPurchases(Long memberId, BasePageRequest pageRequest);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -103,7 +103,7 @@ public class MemberServiceImpl implements MemberService {
         // 회원 존재 여부 확인
         getMember(memberId);
 
-        // 정렬 값이 없는 경우
+        // 정렬값은 최신순으로
         if (pageRequest.getOrder() == null || pageRequest.getOrder().isBlank()) {
             pageRequest.setOrder("DESC");
         }
@@ -118,8 +118,10 @@ public class MemberServiceImpl implements MemberService {
         // 전체 페이지 수
         int totalPages = (totalElements == 0) ? 0 : (int) Math.ceil((double) totalElements / pageRequest.getSize());
 
+        // 현재 페이지에 포함된 데이터 개수
         int numberOfElements = content.size();
 
+        // 이전 페이지 존재 여부
         boolean hasPrevious = pageRequest.getPage() > 0;
 
         // 다음 페이지 존재 여부

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -122,16 +122,16 @@ public class MemberServiceImpl implements MemberService {
         int numberOfElements = content.size();
 
         // 이전 페이지 존재 여부
-        boolean hasPrevious = pageRequest.getPage() > 0;
+        boolean hasPrevious = pageRequest.getPage() > 1;
 
         // 다음 페이지 존재 여부
-        boolean hasNext = pageRequest.getPage() < totalPages - 1;
+        boolean hasNext = pageRequest.getPage() < totalPages;
 
         // 첫 페이지 여부
-        boolean first = pageRequest.getPage() == 0;
+        boolean first = pageRequest.getPage() == 1;
 
         // 마지막 페이지 여부
-        boolean last = totalPages == 0 || pageRequest.getPage() == totalPages - 1;
+        boolean last = totalPages == 0 || pageRequest.getPage() == totalPages;
 
         // 현재 페이지 데이터 비어있는지 여부
         boolean empty = content.isEmpty();

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -115,40 +115,24 @@ public class MemberServiceImpl implements MemberService {
         // 전체 개수 조회
         long totalElements = memberMapper.countPurchasesByMemberId(memberId);
 
-        // 전체 페이지 수
-        int totalPages = (totalElements == 0) ? 0 : (int) Math.ceil((double) totalElements / pageRequest.getSize());
+        PageResponse<MemberPurchaseItemResponse> response = PageResponse.of(
+                content,
+                pageRequest.getPage(),
+                pageRequest.getSize(),
+                totalElements
+        );
 
-        // 현재 페이지에 포함된 데이터 개수
-        int numberOfElements = content.size();
+        int page = pageRequest.getPage();
+        int totalPages = response.getTotalPages();
 
-        // 이전 페이지 존재 여부
-        boolean hasPrevious = pageRequest.getPage() > 1;
+        response.setHasPrevious(page > 1);
+        response.setHasNext(page < totalPages);
+        response.setFirst(page == 1);
+        response.setLast(totalPages == 0 || page == totalPages);
+        response.setEmpty(content.isEmpty());
+        response.setNumberOfElements(content.size());
 
-        // 다음 페이지 존재 여부
-        boolean hasNext = pageRequest.getPage() < totalPages;
-
-        // 첫 페이지 여부
-        boolean first = pageRequest.getPage() == 1;
-
-        // 마지막 페이지 여부
-        boolean last = totalPages == 0 || pageRequest.getPage() == totalPages;
-
-        // 현재 페이지 데이터 비어있는지 여부
-        boolean empty = content.isEmpty();
-
-        return PageResponse.<MemberPurchaseItemResponse>builder()
-                .content(content)
-                .page(pageRequest.getPage())
-                .size(pageRequest.getSize())
-                .totalElements(totalElements)
-                .totalPages(totalPages)
-                .hasNext(hasNext)
-                .hasPrevious(hasPrevious)
-                .first(first)
-                .last(last)
-                .empty(empty)
-                .numberOfElements(numberOfElements)
-                .build();
+        return response;
     }
 
     // 회원 존재 여부 확인

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -2,10 +2,13 @@ package com.biddingmate.biddinggo.member.service;
 
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
+import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
@@ -92,6 +95,58 @@ public class MemberServiceImpl implements MemberService {
 
         // 탈퇴 처리 (soft delete)
         memberMapper.deleteMember(memberId);
+    }
+
+    @Override
+    public PageResponse<MemberPurchaseItemResponse> getMyPurchases(Long memberId, BasePageRequest pageRequest) {
+
+        // 회원 존재 여부 확인
+        getMember(memberId);
+
+        // 정렬 값이 없는 경우
+        if (pageRequest.getOrder() == null || pageRequest.getOrder().isBlank()) {
+            pageRequest.setOrder("DESC");
+        }
+
+        // 구매내역 목록 조회
+        List<MemberPurchaseItemResponse> content =
+                memberMapper.findPurchasesByMemberId(memberId, pageRequest);
+
+        // 전체 개수 조회
+        long totalElements = memberMapper.countPurchasesByMemberId(memberId);
+
+        // 전체 페이지 수
+        int totalPages = (totalElements == 0) ? 0 : (int) Math.ceil((double) totalElements / pageRequest.getSize());
+
+        int numberOfElements = content.size();
+
+        boolean hasPrevious = pageRequest.getPage() > 0;
+
+        // 다음 페이지 존재 여부
+        boolean hasNext = pageRequest.getPage() < totalPages - 1;
+
+        // 첫 페이지 여부
+        boolean first = pageRequest.getPage() == 0;
+
+        // 마지막 페이지 여부
+        boolean last = totalPages == 0 || pageRequest.getPage() == totalPages - 1;
+
+        // 현재 페이지 데이터 비어있는지 여부
+        boolean empty = content.isEmpty();
+
+        return PageResponse.<MemberPurchaseItemResponse>builder()
+                .content(content)
+                .page(pageRequest.getPage())
+                .size(pageRequest.getSize())
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .hasNext(hasNext)
+                .hasPrevious(hasPrevious)
+                .first(first)
+                .last(last)
+                .empty(empty)
+                .numberOfElements(numberOfElements)
+                .build();
     }
 
     // 회원 존재 여부 확인

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -115,24 +115,12 @@ public class MemberServiceImpl implements MemberService {
         // 전체 개수 조회
         long totalElements = memberMapper.countPurchasesByMemberId(memberId);
 
-        PageResponse<MemberPurchaseItemResponse> response = PageResponse.of(
+        return PageResponse.of(
                 content,
                 pageRequest.getPage(),
                 pageRequest.getSize(),
                 totalElements
         );
-
-        int page = pageRequest.getPage();
-        int totalPages = response.getTotalPages();
-
-        response.setHasPrevious(page > 1);
-        response.setHasNext(page < totalPages);
-        response.setFirst(page == 1);
-        response.setLast(totalPages == 0 || page == totalPages);
-        response.setEmpty(content.isEmpty());
-        response.setNumberOfElements(content.size());
-
-        return response;
     }
 
     // 회원 존재 여부 확인

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -161,4 +161,38 @@
         SET status = 'DELETED'
         WHERE id = #{memberId}
     </update>
+
+    <select id="findPurchasesByMemberId" resultType="MemberPurchaseItemResponse">
+        SELECT
+        ai.name AS itemName,
+        seller.name AS sellerName,
+        wd.winner_price AS price,
+        wd.confirmed_at AS completedAt,
+        wd.delivery_status AS deliveryStatus
+        FROM winner_deal wd
+        INNER JOIN auction a ON wd.auction_id = a.id
+        INNER JOIN auction_item ai ON a.item_id = ai.id
+        INNER JOIN member seller ON wd.seller_id = seller.id
+        WHERE wd.winner_id = #{memberId}
+        AND wd.status IN ('PAID', 'CONFIRMED')
+
+        <choose>
+            <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">
+                ORDER BY wd.confirmed_at ASC
+            </when>
+            <otherwise>
+                ORDER BY wd.confirmed_at DESC
+            </otherwise>
+        </choose>
+
+        LIMIT #{pageRequest.limit}
+        OFFSET #{pageRequest.offset}
+    </select>
+
+    <select id="countPurchasesByMemberId" resultType="long">
+        SELECT COUNT(*)
+        FROM winner_deal wd
+        WHERE wd.winner_id = #{memberId}
+          AND wd.status IN ('PAID', 'CONFIRMED')
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 응답 DTO(`MemberPurchaseItemResponse`) 추가
- 구매내역 조회 및 개수 조회 Mapper/XML 쿼리 작성
- `BasePageRequest`, `PageResponse` 기반 페이징 처리 적용
- 정렬값(order) 기본값으로 DESC 설정
- 회원 존재 여부 검증 로직 추가

---

## 📎 관련 이슈

- close #106 
