### PR TITLE
feat: 포인트 환전 처리 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -14,4 +14,6 @@ public interface MemberService {
     void deleteMyAccount(Long memberId);
 
     long getCurrentPoint(Long memberId);
+
+    void deductPoint(Long memberId, Long amount);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -101,6 +101,17 @@ public class MemberServiceImpl implements MemberService {
         return getMember(memberId).getPoint();
     }
 
+    @Override
+    @Transactional
+    public void deductPoint(Long memberId, Long amount) {
+        memberMapper.usePoint(memberId, amount);
+
+        // 리펙터링 대상
+//        if (updated != 1) {
+//            throw new CustomException(ErrorType.NOT_ENOUGH_POINT);
+//        }
+    }
+
     // 회원 존재 여부 확인
     private void memberExists(Long memberId) {
 

--- a/src/main/java/com/biddingmate/biddinggo/point/controller/PointController.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/controller/PointController.java
@@ -2,12 +2,16 @@ package com.biddingmate.biddinggo.point.controller;
 
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.point.dto.ExchangePointRequest;
 import com.biddingmate.biddinggo.point.dto.MyPointResponse;
 import com.biddingmate.biddinggo.point.service.PointService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,5 +28,12 @@ public class PointController {
         MyPointResponse result = pointService.findMyPointList(request, memberId);
 
         return ApiResponse.of(HttpStatus.OK, null, "마이페이지 포인트 내역 조회에 성공했습니다.", result);
+    }
+
+    @PostMapping("/exchanges")
+    public ResponseEntity<ApiResponse<Void>> exchangePoint(@Valid @RequestBody ExchangePointRequest request, @RequestParam Long memberId) {
+        pointService.exchangePoint(request, memberId);
+
+        return ApiResponse.of(HttpStatus.OK, null, "포인트 환전에 성공했습니다.", null);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/dto/ExchangePointRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/dto/ExchangePointRequest.java
@@ -1,0 +1,16 @@
+package com.biddingmate.biddinggo.point.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ExchangePointRequest {
+    @NotNull(message = "환전 포인트는 필수입니다.")
+    @Min(value = 1, message = "환전 포인트는 1 이상이어야 합니다.")
+    private Long amount;
+}

--- a/src/main/java/com/biddingmate/biddinggo/point/model/PointHistoryType.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/model/PointHistoryType.java
@@ -3,5 +3,5 @@ package com.biddingmate.biddinggo.point.model;
 public enum PointHistoryType {
     CHARGE,
     BID,
-    REFUND
+    EXCHANGE
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/service/PointService.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/service/PointService.java
@@ -1,8 +1,10 @@
 package com.biddingmate.biddinggo.point.service;
 
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.point.dto.ExchangePointRequest;
 import com.biddingmate.biddinggo.point.dto.MyPointResponse;
 
 public interface PointService {
     MyPointResponse findMyPointList(BasePageRequest request, Long memberId);
+    void exchangePoint(ExchangePointRequest request, Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/service/PointServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/service/PointServiceImpl.java
@@ -6,14 +6,18 @@ import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView;
 import com.biddingmate.biddinggo.member.service.MemberService;
+import com.biddingmate.biddinggo.point.dto.ExchangePointRequest;
 import com.biddingmate.biddinggo.point.dto.MyPointResponse;
 import com.biddingmate.biddinggo.point.dto.PointHistoryDto;
 import com.biddingmate.biddinggo.point.mapper.PointHistoryMapper;
+import com.biddingmate.biddinggo.point.model.PointHistory;
+import com.biddingmate.biddinggo.point.model.PointHistoryType;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -47,5 +51,24 @@ public class PointServiceImpl implements PointService {
                 .currentPoint(currentPoint)
                 .histroies(pointhistory)
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void exchangePoint(ExchangePointRequest request, Long memberId) {
+        memberService.deductPoint(memberId, request.getAmount());
+
+        PointHistory pointHistory = PointHistory.builder()
+                .memberId(memberId)
+                .type(PointHistoryType.EXCHANGE)
+                .amount(request.getAmount())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        int insert = pointHistoryMapper.insert(pointHistory);
+
+        if (insert != 1) {
+            throw new CustomException(ErrorType.POINT_HISTORY_SAVE_FAILED);
+        }
     }
 }

--- a/src/main/resources/db/migration/V11__update_point_history_type_check.sql
+++ b/src/main/resources/db/migration/V11__update_point_history_type_check.sql
@@ -1,0 +1,3 @@
+ALTER TABLE point_history
+    MODIFY COLUMN type VARCHAR(20)
+    CHECK (type IN ('CHARGE', 'BID', 'EXCHANGE'));


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 포인트 환전 API (POST /api/v1/points/exchanges) 구현
- 환전 요청 시 로그인 사용자 포인트 차감 처리
- 포인트 차감 로직을 MemberService.deductPoint()로 분리하여 공통화
- 환전 내역을 PointHistory에 EXCHANGE 타입으로 기록
- 포인트 차감/히스토리 저장을 하나의 트랜잭션으로 처리하여 데이터 정합성 보장
- 요청 값 검증 추가 (amount >= 1)
- 포인트 부족, 잘못된 요청 등 예외 처리 구현

---

## 📎 관련 이슈
- #105 