### PR TITLE
feat: 경매 관리 조회(판매 중인 상품 조회) API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -58,6 +58,7 @@ public enum ErrorType {
     INVALID_AUCTION_CANCEL_REQUEST("auction-014", "경매 취소 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     AUCTION_UPDATE_NOT_ALLOWED("auction-015", "현재 상태에서는 경매를 수정할 수 없습니다.", HttpStatus.CONFLICT),
     AUCTION_CANCEL_NOT_ALLOWED("auction-016", "현재 상태에서는 경매를 취소할 수 없습니다.", HttpStatus.CONFLICT),
+    INVALID_AUCTION_STATUS("auction-017", "유효하지 않은 경매 상태값입니다.", HttpStatus.BAD_REQUEST),
 
     // 검수
     INVALID_INSPECTION_CREATE_REQUEST("inspection-001", "검수 등록 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
 import com.biddingmate.biddinggo.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -71,5 +72,17 @@ public class MemberController {
     ) {
         PageResponse<MemberPurchaseItemResponse> result = memberService.getMyPurchases(memberId, pageRequest);
         return ApiResponse.of(HttpStatus.OK, null, "구매 내역 조회 성공", result);
+    }
+
+    @GetMapping("/me/auctions")
+    public ResponseEntity<ApiResponse<PageResponse<MemberSellingItemResponse>>> getSellingItems(
+            @RequestParam Long memberId,
+            @RequestParam String status,
+            @Valid BasePageRequest pageRequest
+    ) {
+        PageResponse<MemberSellingItemResponse> result =
+                memberService.getMySellingItems(memberId, status, pageRequest);
+
+        return ApiResponse.of(HttpStatus.OK, null, "판매 중인 상품 조회 성공", result);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSellingItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSellingItemResponse.java
@@ -1,0 +1,34 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberSellingItemResponse {
+
+    // 상품명
+    private String itemName;
+
+    // 현재 최고가
+    private Long currentPrice;
+
+    // 시작가
+    private Long startPrice;
+
+    // 입찰 수
+    private Integer bidCount;
+
+    // 남은 시간(초)
+    private Long remainingSeconds;
+
+    // 경매 타입
+    private String auctionType;
+
+    // 대표 이미지 URL
+    private String imageUrl;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -8,6 +8,7 @@ import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import org.apache.ibatis.annotations.Mapper;
@@ -67,4 +68,12 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
 
     // 총 구매 개수 조회
     long countPurchasesByMemberId(@Param("memberId") Long memberId);
+
+    List<MemberSellingItemResponse> findSellingItemsByMemberId(
+            @Param("memberId") Long memberId,
+            @Param("status") String upperCase,
+            @Param("pageRequest") BasePageRequest pageRequest
+    );
+
+    long countSellingItemsByMemberId(@Param("memberId") Long memberId, @Param("status") String upperCase);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -7,6 +7,8 @@ import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
+import jakarta.validation.Valid;
 
 public interface MemberService {
     MemberDashboardResponse getMyDashboard(Long id);
@@ -24,4 +26,6 @@ public interface MemberService {
     long getCurrentPoint(Long memberId);
 
     void deductPoint(Long memberId, Long amount);
+
+    PageResponse<MemberSellingItemResponse> getMySellingItems(Long memberId, String status, BasePageRequest pageRequest);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
@@ -166,6 +167,38 @@ public class MemberServiceImpl implements MemberService {
 //        if (updated != 1) {
 //            throw new CustomException(ErrorType.NOT_ENOUGH_POINT);
 //        }
+    }
+
+    @Override
+    public PageResponse<MemberSellingItemResponse> getMySellingItems(Long memberId, String status, BasePageRequest pageRequest) {
+
+        // 회원 존재 여부 확인
+        memberExists(memberId);
+
+        // 상태값 검증
+        if (!"ON_GOING".equalsIgnoreCase(status)) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_STATUS);
+        }
+
+        // 정렬값은 최신순으로
+        if (pageRequest.getOrder() == null || pageRequest.getOrder().isBlank()) {
+            pageRequest.setOrder("DESC");
+        }
+
+        // 판매중 상품 목록 조회
+        List<MemberSellingItemResponse> content =
+                memberMapper.findSellingItemsByMemberId(memberId, status.toUpperCase(), pageRequest);
+
+        // 전체 개수 조회
+        long totalElements =
+                memberMapper.countSellingItemsByMemberId(memberId, status.toUpperCase());
+
+        return PageResponse.of(
+                content,
+                pageRequest.getPage(),
+                pageRequest.getSize(),
+                totalElements
+        );
     }
 
     // 회원 존재 여부 확인

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -280,7 +280,7 @@
         </otherwise>
     </choose>
 
-    LIMIT #{pageRequest.limit}
+    LIMIT #{pageRequest.size}
     OFFSET #{pageRequest.offset}
 </select>
 
@@ -317,7 +317,7 @@
         </otherwise>
     </choose>
 
-    LIMIT #{pageRequest.limit}
+    LIMIT #{pageRequest.size}
     OFFSET #{pageRequest.offset}
 </select>
 
@@ -328,4 +328,44 @@
       AND wd.status IN ('PAID', 'CONFIRMED')
 </select>
 
+    <select id="findSellingItemsByMemberId" resultType="MemberSellingItemResponse">
+        SELECT
+        ai.name AS itemName,                                  -- 상품명
+        COALESCE(a.vickrey_price, a.start_price) AS currentPrice, -- 현재 최고가
+        a.start_price AS startPrice,                          -- 시작가
+        a.bid_count AS bidCount,                              -- 입찰 수
+        TIMESTAMPDIFF(SECOND, NOW(), a.end_date) AS remainingSeconds, -- 남은 시간(초)
+        a.type AS auctionType,                                -- 경매 타입
+        ii.url AS imageUrl                                    -- 대표 이미지 URL
+        FROM auction a
+
+        INNER JOIN auction_item ai
+        ON a.item_id = ai.id
+
+        LEFT JOIN item_image ii
+        ON ii.item_id = ai.id
+        AND ii.display_order = 1
+
+        WHERE a.seller_id = #{memberId}
+        AND a.status = #{status}
+
+        <choose>
+            <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">
+                ORDER BY a.end_date ASC
+            </when>
+            <otherwise>
+                ORDER BY a.end_date DESC
+            </otherwise>
+        </choose>
+
+        LIMIT #{pageRequest.size}
+        OFFSET #{pageRequest.offset}
+    </select>
+
+    <select id="countSellingItemsByMemberId" resultType="long">
+        SELECT COUNT(*)
+        FROM auction a
+        WHERE a.seller_id = #{memberId}
+          AND a.status = #{status}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 회원의 (판매 중인 물품) 경매 관리 조회 API 구현
- 경매 상태가 `ON_GOING`인 데이터만 조회하도록 처리
- 상품명, 현재 최고가, 시작가, 입찰 수, 종료 시간, 경매 타입, 대표 이미지 URL 반환
- 서비스 레이어에서 회원 존재 여부 검증 추가
- 잘못된 상태값 요청에 대한 예외 처리 추가
---

## 📎 관련 이슈

- close #121 
