### PR TITLE
feat: 관리자 검수 요청 물품 조회 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/AdminInspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/AdminInspectionController.java
@@ -1,0 +1,32 @@
+package com.biddingmate.biddinggo.inspection.controller;
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
+import com.biddingmate.biddinggo.inspection.service.InspectionQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admins/inspections")
+public class AdminInspectionController {
+    private final InspectionQueryService inspectionQueryService;
+
+    @GetMapping("")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<PageResponse<AdminInspectionListResponse>>> findAllDirectInquiry(
+            AdminInspectionListRequest request) {
+        PageResponse<AdminInspectionListResponse> result = inspectionQueryService.findAllWithFilter(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "관리자 검수 요청 물품 조회 성공", result);
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/AdminInspectionListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/AdminInspectionListRequest.java
@@ -1,0 +1,25 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Schema(description = "검수물품 목록 조회 요청 DTO")
+public class AdminInspectionListRequest extends BasePageRequest {
+    @Schema(description = "검수 상태", example = "PENDING", nullable = true)
+    private InspectionStatus status;
+
+    @Schema(description = "검수 물품명", example = "Galaxy_S25", nullable = true)
+    private String name;
+}
+

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/AdminInspectionListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/AdminInspectionListResponse.java
@@ -1,0 +1,20 @@
+package com.biddingmate.biddinggo.inspection.dto;
+
+import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AdminInspectionListResponse {
+    private Long inspectionId;
+    private Long itemId;
+    private String name;
+    private ItemInspectionStatus status;
+    private String quality;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/mapper/InspectionMapper.java
@@ -1,7 +1,10 @@
 package com.biddingmate.biddinggo.inspection.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
+import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
 import com.biddingmate.biddinggo.inspection.model.Inspection;
 import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
@@ -29,4 +32,10 @@ public interface InspectionMapper extends IMybatisCRUD<Inspection> {
                             @Param("status") ItemInspectionStatus status);
 
     InspectionDetailResponse findDetailById(Long inspectionId);
+
+    List<AdminInspectionListResponse> findAllWithFilter(@Param("request") AdminInspectionListRequest request,
+                                                        RowBounds rowBounds,
+                                                        @Param("order") String sortOrder);
+
+    long countWithFilter(AdminInspectionListRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryService.java
@@ -1,6 +1,8 @@
 package com.biddingmate.biddinggo.inspection.service;
 
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
@@ -19,4 +21,8 @@ public interface InspectionQueryService {
      * 검수 ID를 기준으로 상세 정보를 조회한다.
      */
     InspectionDetailResponse getInspectionDetail(Long inspectionId);
+
+    // 모든 검수 요청 물품 조회
+    // 검수 상태 및 물품명에 의한 필터링 처리
+    PageResponse<AdminInspectionListResponse> findAllWithFilter(AdminInspectionListRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.biddingmate.biddinggo.inspection.service;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListRequest;
+import com.biddingmate.biddinggo.inspection.dto.AdminInspectionListResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionDetailResponse;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListRequest;
 import com.biddingmate.biddinggo.inspection.dto.InspectionListResponse;
@@ -82,5 +84,27 @@ public class InspectionQueryServiceImpl implements InspectionQueryService {
         detail.getItem().setImages(images);
 
         return detail;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AdminInspectionListResponse> findAllWithFilter(AdminInspectionListRequest request) {
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+
+        String order = request.getOrder();
+
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
+
+        String sortOrder = order.toUpperCase();
+
+        List<AdminInspectionListResponse> content =
+                inspectionMapper.findAllWithFilter(request, rowBounds, sortOrder);
+
+        long totalCount =
+                inspectionMapper.countWithFilter(request);
+
+        return PageResponse.of(content, request.getPage(), request.getSize(), totalCount);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,4 +3,11 @@ spring:
     name: bidding-go
   config:
     import: optional:file:.env[.properties]
-
+logging:
+  level:
+    '[org.springframework.web]': info
+    '[org.springframework.security]': info
+    '[org.mybatis]': debug
+    '[org.mariadb.jdbc.client.impl]': info
+    '[org.springframework.data.redis]': info
+    '[io.lettuce.core]': info

--- a/src/main/resources/mapper/inspection/inspection-mapper.xml
+++ b/src/main/resources/mapper/inspection/inspection-mapper.xml
@@ -165,4 +165,42 @@
         </trim>
     </insert>
 
+    <!-- 관리자 검수 요청 물품 조회 -->
+    <select id="findAllWithFilter" parameterType="InspectionListRequest" resultType="AdminInspectionListResponse">
+        SELECT i.id AS inspectionId,
+               ai.id AS itemId,
+               ai.name AS name,
+               i.status AS status,
+               ai.quality AS quality,
+               i.created_at AS createdAt
+        FROM inspection i
+        INNER JOIN auction_item ai ON i.item_id = ai.id
+        <where>
+            <if test="request.status != null">
+                AND i.status = #{request.status}
+            </if>
+            <if test="request.name != null and request.name != ''">
+                AND ai.name LIKE CONCAT('%', #{request.name}, '%')
+            </if>
+        </where>
+        ORDER BY i.created_at ${order}
+    </select>
+
+    <!-- 관리자 검수 요청 물품 조회 페이징 카운트 -->
+    <select id="countWithFilter"
+            parameterType="InspectionListRequest"
+            resultType="long">
+        SELECT COUNT(*)
+        FROM inspection i
+        INNER JOIN auction_item ai ON i.item_id = ai.id
+        <where>
+            <if test="status != null">
+                AND i.status = #{status}
+            </if>
+            <if test="name != null and name != ''">
+                AND ai.name LIKE CONCAT('%', #{name}, '%')
+            </if>
+        </where>
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 관리자 검수 요청 물품 목록 조회 API 구현
- 검수 상태(`InspectionStatus`) 및 물품명 기반 필터링 기능 추가
- `MyBatis` 동적 쿼리(`<where>`, `<if>`)를 활용한 조건 검색 구현
- 최신순/오래된순 정렬 지원 (`created_at` 기준, `ASC/DESC`)
- `RowBounds`를 이용한 페이징 처리 적용

---

## 📎 관련 이슈
- #128 