### PR TITLE
refactor: 입찰, 관심 경매 기능에 인증 객체 주입

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/bid/controller/BidController.java
+++ b/src/main/java/com/biddingmate/biddinggo/bid/controller/BidController.java
@@ -9,12 +9,14 @@ import com.biddingmate.biddinggo.bid.service.BidService;
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.member.model.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,15 +36,11 @@ public class BidController {
     @PostMapping("/bids")
     @Operation(summary = "입찰", description = "경매에 입찰합니다.")
     public ResponseEntity<ApiResponse<CreateBidResponse>> createBid(
-            /*
-              <<to-do>>
-              이후 인증 구현 완료 후, 로그인 정보 받아와서 memberId에 주입
-             */
-            @NotNull @RequestParam Long memberId,
+            @AuthenticationPrincipal Member member,
             @Valid @RequestBody CreateBidRequest request
     ) {
 
-        CreateBidResponse result = bidApplicationService.createBidProcess(memberId, request);
+        CreateBidResponse result = bidApplicationService.createBidProcess(member.getId(), request);
 
         return ApiResponse.of(HttpStatus.OK, null, "입찰 완료", result);
     }
@@ -62,13 +60,9 @@ public class BidController {
     @Operation(summary = "입찰 중인 경매 조회", description = "입찰 중인 경매를 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<AuctionDetailResponse>>> getBidAuctionsForUser(
         BasePageRequest request,
-            /*
-              <<to-do>>
-              이후 인증 구현 완료 후, 로그인 정보 받아와서 memberId에 주입
-             */
-        @NotNull @RequestParam Long memberId
+        @AuthenticationPrincipal Member member
     ) {
-        PageResponse<AuctionDetailResponse> result = bidService.getBidAuctionsByMemberId(request, memberId);
+        PageResponse<AuctionDetailResponse> result = bidService.getBidAuctionsByMemberId(request, member.getId());
 
         return ApiResponse.of(HttpStatus.OK, null, "입찰 중인 경매 조회 성공", result);
     }

--- a/src/main/java/com/biddingmate/biddinggo/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/biddingmate/biddinggo/wishlist/controller/WishlistController.java
@@ -4,6 +4,7 @@ import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.wishlist.dto.CreateWishlistRequest;
 import com.biddingmate.biddinggo.wishlist.dto.CreateWishlistResponse;
 import com.biddingmate.biddinggo.wishlist.service.WishlistService;
@@ -12,14 +13,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import software.amazon.awssdk.annotations.NotNull;
 
 @RestController
 @RequestMapping("/api/v1/wishlists")
@@ -32,14 +32,10 @@ public class WishlistController {
     @Operation(summary = "관심 경매 등록", description = "관심 경매를 등록합니다.")
     public ResponseEntity<ApiResponse<CreateWishlistResponse>> createWishlist(
             @RequestBody CreateWishlistRequest request,
-            /*
-              <<to-do>>
-              이후 인증 구현 완료 후, 로그인 정보 받아와서 memberId에 주입
-             */
-            @NotNull @RequestParam Long memberId
+            @AuthenticationPrincipal Member member
     ) {
 
-        CreateWishlistResponse result = wishlistService.createWishlist(request, memberId);
+        CreateWishlistResponse result = wishlistService.createWishlist(request, member.getId());
 
         return ApiResponse.of(HttpStatus.OK, null, "관심 경매 등록 성공", result);
     }
@@ -48,13 +44,9 @@ public class WishlistController {
     @Operation(summary = "내 관심 경매 조회", description = "사용자의 관심 경매를 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<AuctionDetailResponse>>> getWishlist(
             BasePageRequest request,
-            /*
-              <<to-do>>
-              이후 인증 구현 완료 후, 로그인 정보 받아와서 memberId에 주입
-             */
-            @NotNull @RequestParam Long memberId
+            @AuthenticationPrincipal Member member
     ) {
-        PageResponse<AuctionDetailResponse> result = wishlistService.findWishlistAuctionsByMemberId(request, memberId);
+        PageResponse<AuctionDetailResponse> result = wishlistService.findWishlistAuctionsByMemberId(request, member.getId());
 
         return ApiResponse.of(HttpStatus.OK, null, "관심 경매 조회 성공", result);
     }
@@ -63,14 +55,10 @@ public class WishlistController {
     @Operation(summary = "관심 경매 삭제", description = "관심 경매를 삭제합니다.")
     public ResponseEntity<ApiResponse<Integer>> deleteWishlist(
             @RequestBody CreateWishlistRequest request,
-            /*
-              <<to-do>>
-              이후 인증 구현 완료 후, 로그인 정보 받아와서 memberId에 주입
-             */
-            @NotNull @RequestParam Long memberId
+            @AuthenticationPrincipal Member member
     ) {
 
-        int result = wishlistService.deleteWishlist(request, memberId);
+        int result = wishlistService.deleteWishlist(request, member.getId());
 
         return ApiResponse.of(HttpStatus.OK, null, "관심 경매 삭제 성공", result);
     }


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [x] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 입찰(Bid), 관심 경매(Wishlist) API의 사용자 식별 방식을 리팩토링했습니다
- 기존 요청 파라미터로 전달받던 memberId를 제거했습니다
- @AuthenticationPrincipal을 사용하여 인증된 사용자 정보를 기반으로 memberId를 주입하도록 변경했습니다
- 컨트롤러에서 인증 책임을 명확히 하고, 사용자 식별 방식을 일관되게 통일했습니다

---

## 📎 관련 이슈
- close #134 
