### PR TITLE
feat: 관리자용 사용자 계정 목록 조회 API

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auth/dto/SocialInfoUpdateDto.java
+++ b/src/main/java/com/biddingmate/biddinggo/auth/dto/SocialInfoUpdateDto.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.auth.dto;
 
+import com.biddingmate.biddinggo.member.model.MemberStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,5 +17,5 @@ public class SocialInfoUpdateDto {
     private String username;
     private String name;
     private String nickname;
-    private String status;
+    private MemberStatus status;
 }

--- a/src/main/java/com/biddingmate/biddinggo/auth/service/AdminAuthServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auth/service/AdminAuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
+import com.biddingmate.biddinggo.member.model.MemberStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -71,7 +72,7 @@ public class AdminAuthServiceImpl implements AdminAuthService {
                 .email(signupRequestDto.getEmail())
                 .nickname(signupRequestDto.getNickname())
                 .role("ADMIN")
-                .status("ACTIVE")
+                .status(MemberStatus.ACTIVE)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -138,7 +139,7 @@ public class AdminAuthServiceImpl implements AdminAuthService {
                 .username(username)
                 .name(name)
                 .nickname(nickname)
-                .status("ACTIVE")
+                .status(MemberStatus.ACTIVE)
                 .build();
 
         memberMapper.updateMemberInfo(updateDto);

--- a/src/main/java/com/biddingmate/biddinggo/auth/service/AdminAuthServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auth/service/AdminAuthServiceImpl.java
@@ -166,7 +166,4 @@ public class AdminAuthServiceImpl implements AdminAuthService {
                 .expiredAt(jwtUtil.getExpiredAt(accessToken))
                 .build();
     }
-
-
-
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/AdminMemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/AdminMemberController.java
@@ -7,6 +7,7 @@ import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
 import com.biddingmate.biddinggo.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,5 +19,7 @@ public class AdminMemberController {
     private final MemberService memberService;
 
     @GetMapping("")
-    public ResponseEntity<ApiResponse<PageResponse<MemberListView>>> findAllMemberWithFilter(@Valid MemberListViewRequest request )
+    public ResponseEntity<ApiResponse<PageResponse<MemberListView>>> findAllMemberWithFilter(@Valid MemberListViewRequest request ) {
+        return null;
+    }
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/AdminMemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/AdminMemberController.java
@@ -1,0 +1,22 @@
+package com.biddingmate.biddinggo.member.controller;
+
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.member.dto.MemberListView;
+import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
+import com.biddingmate.biddinggo.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admins/members")
+public class AdminMemberController {
+    private final MemberService memberService;
+
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<PageResponse<MemberListView>>> findAllMemberWithFilter(@Valid MemberListViewRequest request )
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/AdminMemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/AdminMemberController.java
@@ -7,7 +7,9 @@ import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
 import com.biddingmate.biddinggo.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +21,10 @@ public class AdminMemberController {
     private final MemberService memberService;
 
     @GetMapping("")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<PageResponse<MemberListView>>> findAllMemberWithFilter(@Valid MemberListViewRequest request ) {
-        return null;
+        PageResponse<MemberListView> result = memberService.findAllMemberWithFilter(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "관리자용 모든 사용자의 계정 조회 성공", result);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListView.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListView.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.member.dto;
 
+import com.biddingmate.biddinggo.member.model.MemberStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,10 +11,12 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class MemberListView {
-    private Long memberId;
+    private Long id;
     private String nickname;
     private String email;
-    private String status;
+    private MemberStatus status;
     private LocalDateTime createdAt;
-    private int totalCount;
+
+    // 거래 건수 필드는 추후에 추가 예정
+    // private int dealTotalCount;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListView.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListView.java
@@ -1,0 +1,19 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberListView {
+    private Long memberId;
+    private String nickname;
+    private String email;
+    private String status;
+    private LocalDateTime createdAt;
+    private int totalCount;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListViewRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListViewRequest.java
@@ -1,0 +1,14 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberListViewRequest extends BasePageRequest {
+    private String keyword;
+    private String status;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListViewRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberListViewRequest.java
@@ -1,14 +1,15 @@
 package com.biddingmate.biddinggo.member.dto;
 
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.member.model.MemberStatus;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class MemberListViewRequest extends BasePageRequest {
     private String keyword;
-    private String status;
+    private MemberStatus status;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -5,6 +5,7 @@ import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
+import com.biddingmate.biddinggo.member.dto.MemberListView;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
@@ -12,8 +13,10 @@ import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.model.Member;
+import com.biddingmate.biddinggo.member.model.MemberStatus;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.session.RowBounds;
 
 import java.util.List;
 
@@ -84,4 +87,7 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
     );
 
     long countSellingItemsByMemberId(@Param("memberId") Long memberId, @Param("status") String upperCase);
+
+    List<MemberListView> findAllWithFilter(RowBounds rowBounds, String sortOrder, String keyword, MemberStatus status);
+    int countTotalMember(String keyword, MemberStatus status);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/model/Member.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/model/Member.java
@@ -33,7 +33,7 @@ public class Member implements UserDetails {
     private String bankAccount;
     private String grade;
     private String role;
-    private String status;
+    private MemberStatus status;
     private LocalDateTime lastChangeNick;
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/biddingmate/biddinggo/member/model/MemberStatus.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/model/MemberStatus.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.member.model;
 
 public enum MemberStatus {
+    PENDING,
     ACTIVE,
     INACTIVE,
     DELETED

--- a/src/main/java/com/biddingmate/biddinggo/member/model/MemberStatus.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/model/MemberStatus.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.member.model;
+
+public enum MemberStatus {
+    ACTIVE,
+    INACTIVE,
+    DELETED
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.biddingmate.biddinggo.member.service;
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
+import com.biddingmate.biddinggo.member.dto.MemberListView;
+import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
@@ -28,4 +30,6 @@ public interface MemberService {
     void deductPoint(Long memberId, Long amount);
 
     PageResponse<MemberSellingItemResponse> getMySellingItems(Long memberId, String status, BasePageRequest pageRequest);
+
+    PageResponse<MemberListView> findAllMemberWithFilter(@Valid MemberListViewRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -4,8 +4,11 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.directinquiry.dto.DirectInquiryView;
 import com.biddingmate.biddinggo.member.dto.MemberBiddingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
+import com.biddingmate.biddinggo.member.dto.MemberListView;
+import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
@@ -15,6 +18,7 @@ import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.model.Member;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -199,6 +203,25 @@ public class MemberServiceImpl implements MemberService {
                 pageRequest.getSize(),
                 totalElements
         );
+    }
+
+    @Override
+    public PageResponse<MemberListView> findAllMemberWithFilter(MemberListViewRequest request) {
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        String order = request.getOrder();
+
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
+        String sortOrder = order.toUpperCase();
+
+        List<MemberListView> list;
+        int count;
+
+        list = memberMapper.findAllWithFilter(rowBounds, sortOrder, request.getKeyword(), request.getStatus());
+        count = memberMapper.countTotalMember(request.getKeyword(), request.getStatus());
+
+        return PageResponse.of(list, request.getPage(), request.getSize(), count);
     }
 
     // 회원 존재 여부 확인

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -412,4 +412,47 @@
         WHERE a.seller_id = #{memberId}
           AND a.status = #{status}
     </select>
+
+    <!-- 관리자용 모든 사용자 계정 조회 -->
+    <select id="findAllWithFilter" resultType="MemberListView">
+        SELECT id,
+               nickname,
+               email,
+               status,
+               created_at AS createdAt
+        FROM member
+        <where>
+            role = 'USER'
+            <if test="keyword != null and keyword != ''">
+                AND (
+                nickname LIKE CONCAT('%', #{keyword}, '%')
+                OR email LIKE CONCAT('%', #{keyword}, '%')
+                )
+            </if>
+
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+        </where>
+        ORDER BY created_at ${sortOrder}
+    </select>
+
+    <select id="countTotalMember" resultType="int">
+        SELECT COUNT(*)
+        FROM member
+        <where>
+            role = 'USER'
+            <if test="keyword != null and keyword != ''">
+                AND (
+                name LIKE CONCAT('%', #{keyword}, '%')
+                OR email LIKE CONCAT('%', #{keyword}, '%')
+                )
+            </if>
+
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+        </where>
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 관리자용 모든 사용자 계정 조회 API 구현
- 사용자 검색 기능 추가 (이름 / 이메일 `keyword` 검색)
- 사용자 상태 기반 필터링 기능 추가
- 정렬 조건(`ASC/DESC`) 적용
- `RowBounds` 기반 페이징 적용
- 사용자별 거래 개수(`dealTotalCount`)는 추후에 확장하도록 주석처리
---

## 📎 관련 이슈
- #136 