### PR TITLE
feat: 알림 등록, 조회, 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -136,6 +136,9 @@ public enum ErrorType {
     NOT_THE_WINNER("review-005", "낙찰자만 해당 경매의 리뷰를 남길 수 있습니다.", HttpStatus.FORBIDDEN),
     SELLER_NOT_FOUND("review-006", "해당 경매의 판매자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
+    // 알림
+    NOTIFICATOIN_SAVE_FAILED("notification-001", "알림 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
     // 공지사항
     NOTICE_NOT_FOUND("notice-001", "해당 공지사항을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTICE_CREATE_FAIL("notice-002", "공지사항 등록을 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
@@ -1,11 +1,12 @@
 package com.biddingmate.biddinggo.notification.controller;
 
-import com.biddingmate.biddinggo.bid.dto.CreateBidRequest;
-import com.biddingmate.biddinggo.bid.dto.CreateBidResponse;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
+import com.biddingmate.biddinggo.notification.dto.NotificationResponse;
 import com.biddingmate.biddinggo.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,14 +15,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/notification")
+@RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
 @Tag(name = "Notification", description = "알림 API")
 public class NotificationController {
@@ -29,10 +30,12 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     /*
-        추후 알림 발생되는 곳에 모두 알림 등록 프로세스를 구현하면 알림 등록 api 는 삭제 예정
+        추후 알림 발생되는 곳에
+        모두 알림 등록 프로세스를 구현하면 (notificationService 를 사용하여)
+        알림 등록 api 는 삭제 예정
      */
     @PostMapping("/")
-    @Operation(summary = "알림", description = "알림을 등록합니다.")
+    @Operation(summary = "알림 등록", description = "알림을 등록합니다.")
     public ResponseEntity<ApiResponse<CreateNotificationResponse>> createBid(
             @Valid @RequestBody CreateNotificationRequest request
     ) {
@@ -41,4 +44,25 @@ public class NotificationController {
 
         return ApiResponse.of(HttpStatus.OK, null, "알림 등록 성공", result);
     }
+
+    @GetMapping("/")
+    @Operation(summary = "알림 조회", description = "알림을 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<NotificationResponse>>> getNotificationsByMemberId(
+            BasePageRequest request,
+            @AuthenticationPrincipal Member member
+    ){
+
+        PageResponse<NotificationResponse> result = notificationService.getNotificationsByMemberId(request, member.getId());
+
+        return ApiResponse.of(HttpStatus.OK, null, "알림 조회 성공", result);
+    }
+
+//    @PatchMapping("/read-all")
+//    @Operation(summary = "전체 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+//    public ResponseEntity<ApiResponse<NotificationReadResponse>> readAllNotification(
+//            @AuthenticationPrincipal Member member
+//    ){
+//
+//        return ApiResponse.of(HttpStatus.OK, null, "전체 알림 읽음 처리", result);
+//    }
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
@@ -1,0 +1,44 @@
+package com.biddingmate.biddinggo.notification.controller;
+
+import com.biddingmate.biddinggo.bid.dto.CreateBidRequest;
+import com.biddingmate.biddinggo.bid.dto.CreateBidResponse;
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.member.model.Member;
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
+import com.biddingmate.biddinggo.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notification")
+@RequiredArgsConstructor
+@Tag(name = "Notification", description = "알림 API")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /*
+        추후 알림 발생되는 곳에 모두 알림 등록 프로세스를 구현하면 알림 등록 api 는 삭제 예정
+     */
+    @PostMapping("/")
+    @Operation(summary = "알림", description = "알림을 등록합니다.")
+    public ResponseEntity<ApiResponse<CreateNotificationResponse>> createBid(
+            @Valid @RequestBody CreateNotificationRequest request
+    ) {
+
+        CreateNotificationResponse result = notificationService.createNotification(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "알림 등록 성공", result);
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
@@ -16,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,12 +59,24 @@ public class NotificationController {
         return ApiResponse.of(HttpStatus.OK, null, "알림 조회 성공", result);
     }
 
-//    @PatchMapping("/read-all")
-//    @Operation(summary = "전체 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
-//    public ResponseEntity<ApiResponse<NotificationReadResponse>> readAllNotification(
-//            @AuthenticationPrincipal Member member
-//    ){
-//
-//        return ApiResponse.of(HttpStatus.OK, null, "전체 알림 읽음 처리", result);
-//    }
+    @PatchMapping("/read-all")
+    @Operation(summary = "전체 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> readAllNotification(
+            @AuthenticationPrincipal Member member
+    ){
+        notificationService.markAllAsRead(member.getId());
+
+        return ApiResponse.of(HttpStatus.OK, null, "전체 알림 읽음 처리", null);
+    }
+
+    @PatchMapping("/{id}/read")
+    @Operation(summary = "단건 알림 읽음 처리", description = "단건 알림을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> readAllNotification(
+            @PathVariable Long id,
+            @AuthenticationPrincipal Member member
+    ){
+        notificationService.markAsRead(id, member.getId());
+
+        return ApiResponse.of(HttpStatus.OK, null, "단건 알림 읽음 처리", null);
+    }
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/dto/CreateNotificationRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/dto/CreateNotificationRequest.java
@@ -1,0 +1,30 @@
+package com.biddingmate.biddinggo.notification.dto;
+
+import com.biddingmate.biddinggo.notification.model.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "알림 등록 요청 DTO")
+public class CreateNotificationRequest {
+    @NotNull(message = "수신자 ID는 필수입니다.")
+    private Long receiverId;
+
+    @NotNull(message = "알림 유형은 필수입니다.")
+    private NotificationType type;
+
+    @NotNull(message = "알림 내용은 필수입니다.")
+    private String content;
+
+    private String url;
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/dto/CreateNotificationResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/dto/CreateNotificationResponse.java
@@ -1,0 +1,15 @@
+package com.biddingmate.biddinggo.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "알림 등록 응답 DTO")
+public class CreateNotificationResponse {
+    @Schema(description = "생성된 알림 ID")
+    private Long id;
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/dto/NotificationResponse.java
@@ -2,26 +2,23 @@ package com.biddingmate.biddinggo.notification.dto;
 
 import com.biddingmate.biddinggo.notification.model.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "알림 등록 요청 DTO")
-public class CreateNotificationRequest {
-    @NotNull(message = "수신자 ID는 필수입니다.")
+@Schema(description = "알림 조회 응답 DTO")
+public class NotificationResponse {
+    @Schema(description = "조회된 알림")
+    private Long id;
     private Long receiverId;
-
-    @NotNull(message = "알림 유형은 필수입니다.")
     private NotificationType type;
-
-    @NotNull(message = "알림 내용은 필수입니다.")
     private String content;
-
     private String url;
+    private LocalDateTime readAt;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
@@ -17,4 +17,8 @@ public interface NotificationMapper extends IMybatisCRUD<Notification> {
                                                           @Param("order") String sortOrder);
 
     int getNotificationCount(Map<String, Long> params);
+
+    void updateReadAtByMemberId(@Param("receiverId") Long receiverId);
+
+    void updateReadAtById(@Param("id") Long id, @Param("receiverId") Long receiverId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
@@ -1,9 +1,20 @@
 package com.biddingmate.biddinggo.notification.mapper;
 
 import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.notification.dto.NotificationResponse;
 import com.biddingmate.biddinggo.notification.model.Notification;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface NotificationMapper extends IMybatisCRUD<Notification> {
+    List<NotificationResponse> getNotificationsByMemberId(RowBounds rowBounds,
+                                                          @Param("receiverId") Long receiverId,
+                                                          @Param("order") String sortOrder);
+
+    int getNotificationCount(Map<String, Long> params);
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
@@ -1,0 +1,9 @@
+package com.biddingmate.biddinggo.notification.mapper;
+
+import com.biddingmate.biddinggo.common.inif.IMybatisCRUD;
+import com.biddingmate.biddinggo.notification.model.Notification;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface NotificationMapper extends IMybatisCRUD<Notification> {
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/model/Notification.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/model/Notification.java
@@ -1,0 +1,23 @@
+package com.biddingmate.biddinggo.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+    private Long id;
+    private Long receiverId;
+    private NotificationType type;
+    private String content;
+    private String url;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/model/Notification.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/model/Notification.java
@@ -19,5 +19,6 @@ public class Notification {
     private NotificationType type;
     private String content;
     private String url;
+    private LocalDateTime readAt;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/model/NotificationType.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/model/NotificationType.java
@@ -1,0 +1,6 @@
+package com.biddingmate.biddinggo.notification.model;
+
+public enum NotificationType {
+    DELIVERY,
+    WIN
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
@@ -1,0 +1,9 @@
+package com.biddingmate.biddinggo.notification.service;
+
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
+import jakarta.validation.Valid;
+
+public interface NotificationService{
+    CreateNotificationResponse createNotification(@Valid CreateNotificationRequest request);
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
@@ -11,4 +11,8 @@ public interface NotificationService{
     CreateNotificationResponse createNotification(@Valid CreateNotificationRequest request);
 
     PageResponse<NotificationResponse> getNotificationsByMemberId(BasePageRequest request, Long receiverId);
+
+    void markAllAsRead(Long receiverId);
+
+    void markAsRead(Long id, Long receiverId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
@@ -1,9 +1,14 @@
 package com.biddingmate.biddinggo.notification.service;
 
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
+import com.biddingmate.biddinggo.notification.dto.NotificationResponse;
 import jakarta.validation.Valid;
 
 public interface NotificationService{
     CreateNotificationResponse createNotification(@Valid CreateNotificationRequest request);
+
+    PageResponse<NotificationResponse> getNotificationsByMemberId(BasePageRequest request, Long receiverId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,49 @@
+package com.biddingmate.biddinggo.notification.service;
+
+import com.biddingmate.biddinggo.common.exception.CustomException;
+import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.member.mapper.MemberMapper;
+import com.biddingmate.biddinggo.member.service.MemberService;
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
+import com.biddingmate.biddinggo.notification.mapper.NotificationMapper;
+import com.biddingmate.biddinggo.notification.model.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final NotificationMapper notificationMapper;
+    private final MemberService memberService;
+    private final MemberMapper memberMapper;
+
+    @Override
+    public CreateNotificationResponse createNotification(CreateNotificationRequest request) {
+
+        // 입력값 확인
+        if (memberMapper.findById(request.getReceiverId()) == null) {
+            throw new CustomException(ErrorType.MEMBER_NOT_FOUND);
+        }
+
+        Notification notification = Notification.builder()
+                .receiverId(request.getReceiverId())
+                .type(request.getType())
+                .content(request.getContent())
+                .url(request.getUrl())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        int result = notificationMapper.insert(notification);
+
+        if(result != 1 || notification.getId() == null){
+            throw new CustomException(ErrorType.NOTIFICATOIN_SAVE_FAILED);
+        }
+
+        return CreateNotificationResponse.builder()
+                .id(notification.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
@@ -67,4 +67,14 @@ public class NotificationServiceImpl implements NotificationService {
         return PageResponse.of(notifications, request.getPage(), request.getSize(), bidCount);
 
     }
+
+    @Override
+    public void markAllAsRead(Long receiverId) {
+        notificationMapper.updateReadAtByMemberId(receiverId);
+    }
+
+    @Override
+    public void markAsRead(Long id, Long receiverId) {
+        notificationMapper.updateReadAtById(id, receiverId);
+    }
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
@@ -2,22 +2,26 @@ package com.biddingmate.biddinggo.notification.service;
 
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
-import com.biddingmate.biddinggo.member.service.MemberService;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
+import com.biddingmate.biddinggo.notification.dto.NotificationResponse;
 import com.biddingmate.biddinggo.notification.mapper.NotificationMapper;
 import com.biddingmate.biddinggo.notification.model.Notification;
 import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationServiceImpl implements NotificationService {
     private final NotificationMapper notificationMapper;
-    private final MemberService memberService;
     private final MemberMapper memberMapper;
 
     @Override
@@ -45,5 +49,22 @@ public class NotificationServiceImpl implements NotificationService {
         return CreateNotificationResponse.builder()
                 .id(notification.getId())
                 .build();
+    }
+
+    @Override
+    public PageResponse<NotificationResponse> getNotificationsByMemberId(BasePageRequest request, Long receiverId) {
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        String order = request.getOrder();
+
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
+        String sortOrder = order.toUpperCase();
+
+        List<NotificationResponse> notifications = notificationMapper.getNotificationsByMemberId(rowBounds, receiverId, sortOrder);
+        int bidCount = notificationMapper.getNotificationCount(Map.of("receiverId", receiverId));
+
+        return PageResponse.of(notifications, request.getPage(), request.getSize(), bidCount);
+
     }
 }

--- a/src/main/resources/mapper/bid/bid-mapper.xml
+++ b/src/main/resources/mapper/bid/bid-mapper.xml
@@ -53,7 +53,7 @@
                 SELECT COUNT(*) FROM bid WHERE auction_id = #{auctionId} AND status = 'ACTIVE'
             </when>
             <when test="bidderId != null">
-                SELECT COUNT(DISTINCT auction_id) FROM bid WHERE bidder_id = #{bidderId} AND status = 'ACTIVE'
+                SELECT COUNT(*) FROM bid WHERE bidder_id = #{bidderId} AND status = 'ACTIVE'
             </when>
             <otherwise>
                 SELECT 0

--- a/src/main/resources/mapper/notification/notification-mapper.xml
+++ b/src/main/resources/mapper/notification/notification-mapper.xml
@@ -36,4 +36,19 @@
         FROM notification
         WHERE receiver_id = #{receiverId}
     </select>
+
+    <update id="updateReadAtByMemberId">
+        UPDATE notification
+        SET read_at = NOW()
+        WHERE receiver_id = #{receiverId}
+          AND ISNULL(read_at)
+    </update>
+
+    <update id="updateReadAtById">
+        UPDATE notification
+        SET read_at = NOW()
+        WHERE id = #{id}
+          AND receiver_id = #{receiverId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/notification/notification-mapper.xml
+++ b/src/main/resources/mapper/notification/notification-mapper.xml
@@ -18,4 +18,22 @@
                      #{createdAt}
                  )
     </insert>
+
+    <select id="getNotificationsByMemberId">
+        SELECT id,
+               receiver_id AS receiverId,
+               type,
+               content,
+               url,
+               read_at AS readAt,
+               created_at AS createdAt
+        FROM notification
+        WHERE receiver_id = #{receiverId}
+    </select>
+
+    <select id="getNotificationCount">
+        SELECT COUNT(*)
+        FROM notification
+        WHERE receiver_id = #{receiverId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/notification/notification-mapper.xml
+++ b/src/main/resources/mapper/notification/notification-mapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.biddingmate.biddinggo.notification.mapper.NotificationMapper">
+
+    <insert id="insert" parameterType="Notification" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO notification(
+            receiver_id,
+            type,
+            content,
+            <if test="url != null">url,</if>
+            created_at
+        ) VALUES (
+                     #{receiverId},
+                     #{type},
+                     #{content},
+                     <if test="url != null">#{url},</if>
+                     #{createdAt}
+                 )
+    </insert>
+</mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- POST /api/v1/notifications 엔드포인트 구현
- GET /api/v1/notifications 엔드포인트 구현
- PATCH /api/v1/notifications/{id}/read 엔드포인트 구현
- PATCH /api/v1/notifications/read-all 엔드포인트 구현
- 사용자 본인 알림만 조회 및 읽음 처리 가능하도록 조건 적용
- 단건 읽음 처리 시 notification id와 receiver id 기반 검증 로직 반영
- 전체 읽음 처리 시 read_at이 null인 데이터만 갱신하도록 구현
- 이미 읽음 상태 또는 본인 알림이 아닌 경우에도 예외를 발생시키지 않고, 쿼리 조건으로 대상 데이터를 필터링하여 처리

---

## 📎 관련 이슈
- close #159 
