### PR TITLE
feat: 유사도 기반 경매 검색 기능 추가

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
@@ -49,11 +49,11 @@ public class AuctionController {
     }
 
     @GetMapping("/search/semantic")
-    @Operation(summary = "유사도 기반 경매 검색", description = "검색어를 기반으로 유사한 진행 중 경매를 최신순으로 조회합니다.")
+    @Operation(summary = "유사도 기반 경매 검색", description = "검색어를 기반으로 유사한 진행 중 경매를 조회하며, 정렬은 기존 경매 목록 기준을 따릅니다.")
     public ResponseEntity<ApiResponse<PageResponse<AuctionListResponse>>> searchAuctionsBySemantic(
             @Valid AuctionSemanticSearchRequest request) {
 
-        // semantic search는 후보 추출만 유사도 기반으로 수행하고, 최종 정렬은 최신순으로 고정한다.
+        // semantic search는 후보 추출만 유사도 기반으로 수행하고, 최종 정렬은 기존 목록 규칙을 따른다.
         PageResponse<AuctionListResponse> result = auctionQueryService.searchAuctionsBySemantic(request);
 
         return ApiResponse.of(HttpStatus.OK, null, "유사도 기반 경매 검색 완료", result);

--- a/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
@@ -53,6 +53,7 @@ public class AuctionController {
     public ResponseEntity<ApiResponse<PageResponse<AuctionListResponse>>> searchAuctionsBySemantic(
             @Valid AuctionSemanticSearchRequest request) {
 
+        // semantic search는 후보 추출만 유사도 기반으로 수행하고, 최종 정렬은 최신순으로 고정한다.
         PageResponse<AuctionListResponse> result = auctionQueryService.searchAuctionsBySemantic(request);
 
         return ApiResponse.of(HttpStatus.OK, null, "유사도 기반 경매 검색 완료", result);

--- a/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/controller/AuctionController.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.auction.controller;
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.auction.dto.AuctionListRequest;
 import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
+import com.biddingmate.biddinggo.auction.dto.AuctionSemanticSearchRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionFromInspectionItemRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionResponse;
@@ -45,6 +46,16 @@ public class AuctionController {
         PageResponse<AuctionListResponse> result = auctionQueryService.getAuctionList(request);
 
         return ApiResponse.of(HttpStatus.OK, null, "경매 목록 조회 완료", result);
+    }
+
+    @GetMapping("/search/semantic")
+    @Operation(summary = "유사도 기반 경매 검색", description = "검색어를 기반으로 유사한 진행 중 경매를 최신순으로 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<AuctionListResponse>>> searchAuctionsBySemantic(
+            @Valid AuctionSemanticSearchRequest request) {
+
+        PageResponse<AuctionListResponse> result = auctionQueryService.searchAuctionsBySemantic(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "유사도 기반 경매 검색 완료", result);
     }
 
     @GetMapping("/{auctionId}")

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionSemanticSearchRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionSemanticSearchRequest.java
@@ -1,0 +1,22 @@
+package com.biddingmate.biddinggo.auction.dto;
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Schema(description = "유사도 기반 경매 검색 요청 DTO")
+public class AuctionSemanticSearchRequest extends BasePageRequest {
+    @NotBlank(message = "검색어는 필수입니다.")
+    @Schema(description = "검색어", example = "나이키 조던 검정 하이탑")
+    private String q;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionSemanticSearchRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionSemanticSearchRequest.java
@@ -5,22 +5,28 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
 /**
  * 유사도 기반 경매 검색 요청 DTO.
- * 검색어는 필수이고, 최종 정렬은 서버에서 최신순으로 고정한다.
+ * 검색어는 필수이고, 정렬 기준은 기존 경매 목록 규칙을 재사용한다.
+ * 기본 정렬은 최신순(CREATED_AT DESC)이다.
  */
 @Schema(description = "유사도 기반 경매 검색 요청 DTO")
 public class AuctionSemanticSearchRequest extends BasePageRequest {
+    public AuctionSemanticSearchRequest() {
+        setOrder("DESC");
+    }
+
     @NotBlank(message = "검색어는 필수입니다.")
     @Schema(description = "검색어", example = "나이키 조던 검정 하이탑")
     private String q;
+
+    @Schema(description = "정렬 기준", example = "CREATED_AT", allowableValues = {"CREATED_AT", "WISH_COUNT", "POPULARITY", "PRICE"}, nullable = true)
+    private String sortBy;
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionSemanticSearchRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/dto/AuctionSemanticSearchRequest.java
@@ -14,6 +14,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
+/**
+ * 유사도 기반 경매 검색 요청 DTO.
+ * 검색어는 필수이고, 최종 정렬은 서버에서 최신순으로 고정한다.
+ */
 @Schema(description = "유사도 기반 경매 검색 요청 DTO")
 public class AuctionSemanticSearchRequest extends BasePageRequest {
     @NotBlank(message = "검색어는 필수입니다.")

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -27,6 +27,13 @@ public interface AuctionMapper extends IMybatisCRUD<Auction> {
                          @Param("sellerId") Long sellerId,
                          @Param("categoryId") Long categoryId);
 
+    List<AuctionListResponse> findAuctionListByAuctionIds(RowBounds rowBounds,
+                                                          @Param("auctionIds") List<Long> auctionIds,
+                                                          @Param("status") AuctionStatus status);
+
+    int countAuctionListByAuctionIds(@Param("auctionIds") List<Long> auctionIds,
+                                     @Param("status") AuctionStatus status);
+
     int updateAuction(Auction auction);
 
     int cancelAuction(@Param("auctionId") Long auctionId,

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -33,7 +33,9 @@ public interface AuctionMapper extends IMybatisCRUD<Auction> {
      */
     List<AuctionListResponse> findAuctionListByAuctionIds(RowBounds rowBounds,
                                                           @Param("auctionIds") List<Long> auctionIds,
-                                                          @Param("status") AuctionStatus status);
+                                                          @Param("status") AuctionStatus status,
+                                                          @Param("sortBy") String sortBy,
+                                                          @Param("order") String order);
 
     /**
      * 후보 auction ID 집합 중 실제 조회 조건을 만족하는 경매 수를 반환한다.

--- a/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/mapper/AuctionMapper.java
@@ -27,10 +27,17 @@ public interface AuctionMapper extends IMybatisCRUD<Auction> {
                          @Param("sellerId") Long sellerId,
                          @Param("categoryId") Long categoryId);
 
+    /**
+     * Supabase에서 찾은 후보 auction ID 집합을 기준으로 실제 경매 목록을 조회한다.
+     * 최종 정렬과 상태 필터는 MariaDB 기준으로 다시 적용한다.
+     */
     List<AuctionListResponse> findAuctionListByAuctionIds(RowBounds rowBounds,
                                                           @Param("auctionIds") List<Long> auctionIds,
                                                           @Param("status") AuctionStatus status);
 
+    /**
+     * 후보 auction ID 집합 중 실제 조회 조건을 만족하는 경매 수를 반환한다.
+     */
     int countAuctionListByAuctionIds(@Param("auctionIds") List<Long> auctionIds,
                                      @Param("status") AuctionStatus status);
 

--- a/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/AuctionPredictionSupabaseClient.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/AuctionPredictionSupabaseClient.java
@@ -45,7 +45,8 @@ public interface AuctionPredictionSupabaseClient {
     );
 
     /**
-     * 검색어 임베딩을 기준으로 유사한 경매 query embedding을 검색한다.
+     * 검색어 임베딩을 기준으로 유사한 경매 query embedding 후보를 검색한다.
+     * 최종 정렬/상태 필터는 애플리케이션의 MariaDB 조회 단계에서 다시 적용한다.
      */
     List<AuctionQueryEmbeddingMatch> matchAuctionQueryEmbeddings(
             List<Double> queryEmbedding,

--- a/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/AuctionPredictionSupabaseClient.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/AuctionPredictionSupabaseClient.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.auction.prediction.client;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionPriceReference;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionPriceReferenceMatch;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionQueryEmbedding;
+import com.biddingmate.biddinggo.auction.prediction.model.AuctionQueryEmbeddingMatch;
 
 import java.util.List;
 
@@ -41,5 +42,14 @@ public interface AuctionPredictionSupabaseClient {
             Integer matchCount,
             Double minSimilarity,
             Long excludeAuctionId
+    );
+
+    /**
+     * 검색어 임베딩을 기준으로 유사한 경매 query embedding을 검색한다.
+     */
+    List<AuctionQueryEmbeddingMatch> matchAuctionQueryEmbeddings(
+            List<Double> queryEmbedding,
+            Integer matchCount,
+            Double minSimilarity
     );
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/SupabaseAuctionPredictionWebClient.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/SupabaseAuctionPredictionWebClient.java
@@ -206,6 +206,7 @@ public class SupabaseAuctionPredictionWebClient implements AuctionPredictionSupa
         }
 
         Map<String, Object> requestBody = new LinkedHashMap<>();
+        // pgvector RPC 함수가 기대하는 형식으로 query embedding과 검색 조건을 전달한다.
         requestBody.put("query_embedding", toVectorLiteral(queryEmbedding));
         requestBody.put("match_count", matchCount);
         requestBody.put("min_similarity", minSimilarity);
@@ -226,6 +227,7 @@ public class SupabaseAuctionPredictionWebClient implements AuctionPredictionSupa
             return List.of();
         }
 
+        // Supabase에서는 후보 ID 집합만 받고, 실제 경매 조회는 MariaDB에서 이어서 수행한다.
         return rows.stream()
                 .filter(Objects::nonNull)
                 .map(row -> AuctionQueryEmbeddingMatch.builder()

--- a/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/SupabaseAuctionPredictionWebClient.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/prediction/client/SupabaseAuctionPredictionWebClient.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.auction.prediction.client;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionPriceReference;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionPriceReferenceMatch;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionQueryEmbedding;
+import com.biddingmate.biddinggo.auction.prediction.model.AuctionQueryEmbeddingMatch;
 import com.biddingmate.biddinggo.config.AuctionPredictionSupabaseProperties;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.RequiredArgsConstructor;
@@ -194,6 +195,47 @@ public class SupabaseAuctionPredictionWebClient implements AuctionPredictionSupa
                 .toList();
     }
 
+    @Override
+    public List<AuctionQueryEmbeddingMatch> matchAuctionQueryEmbeddings(
+            List<Double> queryEmbedding,
+            Integer matchCount,
+            Double minSimilarity
+    ) {
+        if (!isEnabled()) {
+            throw new IllegalStateException("Auction prediction supabase client is not configured.");
+        }
+
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("query_embedding", toVectorLiteral(queryEmbedding));
+        requestBody.put("match_count", matchCount);
+        requestBody.put("min_similarity", minSimilarity);
+
+        List<QueryEmbeddingMatchRow> rows = webClient.post()
+                .uri(normalizeBaseUrl(properties.getUrl()) + "/rest/v1/rpc/match_auction_query_embedding")
+                .headers(this::applySupabaseHeaders)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<QueryEmbeddingMatchRow>>() {
+                })
+                .timeout(Duration.ofMillis(properties.getTimeoutMillis()))
+                .block();
+
+        if (rows == null) {
+            return List.of();
+        }
+
+        return rows.stream()
+                .filter(Objects::nonNull)
+                .map(row -> AuctionQueryEmbeddingMatch.builder()
+                        .auctionId(row.auctionId())
+                        .itemId(row.itemId())
+                        .categoryId(row.categoryId())
+                        .build())
+                .toList();
+    }
+
     /**
      * 지정한 Supabase RPC 함수를 공통 방식으로 호출한다.
      */
@@ -318,6 +360,13 @@ public class SupabaseAuctionPredictionWebClient implements AuctionPredictionSupa
             @JsonAlias("winner_price") Long winnerPrice,
             @JsonAlias("condition_score") Double conditionScore,
             Double similarity
+    ) {
+    }
+
+    private record QueryEmbeddingMatchRow(
+            @JsonAlias("auction_id") Long auctionId,
+            @JsonAlias("item_id") Long itemId,
+            @JsonAlias("category_id") Long categoryId
     ) {
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/prediction/model/AuctionQueryEmbeddingMatch.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/prediction/model/AuctionQueryEmbeddingMatch.java
@@ -11,6 +11,10 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+/**
+ * semantic search 1차 후보 추출 결과 모델.
+ * 최종 경매 정보는 이 ID들을 기준으로 MariaDB에서 다시 조회한다.
+ */
 public class AuctionQueryEmbeddingMatch {
     private Long auctionId;
     private Long itemId;

--- a/src/main/java/com/biddingmate/biddinggo/auction/prediction/model/AuctionQueryEmbeddingMatch.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/prediction/model/AuctionQueryEmbeddingMatch.java
@@ -1,0 +1,18 @@
+package com.biddingmate.biddinggo.auction.prediction.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuctionQueryEmbeddingMatch {
+    private Long auctionId;
+    private Long itemId;
+    private Long categoryId;
+}

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.auction.service;
 import com.biddingmate.biddinggo.auction.dto.AuctionListRequest;
 import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
+import com.biddingmate.biddinggo.auction.dto.AuctionSemanticSearchRequest;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 
 /**
@@ -19,4 +20,10 @@ public interface AuctionQueryService {
      * 경매 ID를 기준으로 상세 정보를 조회한다.
      */
     AuctionDetailResponse getAuctionDetail(Long auctionId);
+
+    /**
+     * 검색어를 기반으로 유사한 경매 후보를 조회한다.
+     * 실제 검색 구현은 후속 단계에서 연결한다.
+     */
+    PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
@@ -23,7 +23,7 @@ public interface AuctionQueryService {
 
     /**
      * 검색어를 임베딩해 유사한 경매 후보를 찾고,
-     * 최종적으로 진행 중 경매만 최신순으로 반환한다.
+     * 최종적으로 진행 중 경매만 기존 목록 정렬 기준으로 반환한다.
      */
     PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryService.java
@@ -22,8 +22,8 @@ public interface AuctionQueryService {
     AuctionDetailResponse getAuctionDetail(Long auctionId);
 
     /**
-     * 검색어를 기반으로 유사한 경매 후보를 조회한다.
-     * 실제 검색 구현은 후속 단계에서 연결한다.
+     * 검색어를 임베딩해 유사한 경매 후보를 찾고,
+     * 최종적으로 진행 중 경매만 최신순으로 반환한다.
      */
     PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -35,7 +35,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
     private static final String SORT_BY_POPULARITY = "POPULARITY";
     private static final String SORT_BY_PRICE = "PRICE";
     private static final int SEMANTIC_SEARCH_TOP_K = 100;
-    private static final double SEMANTIC_SEARCH_MIN_SIMILARITY = 0.45d;
+    private static final double SEMANTIC_SEARCH_MIN_SIMILARITY = 0.35d;
 
     private final AuctionMapper auctionMapper;
     private final ItemImageMapper itemImageMapper;
@@ -73,12 +73,15 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
     public PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request) {
         validateSortOrder(request.getOrder());
 
+        // 외부 임베딩/Supabase 검색이 꺼져 있으면 빈 결과로 처리한다.
         if (!auctionEmbeddingClient.isEnabled() || !auctionPredictionSupabaseClient.isEnabled()) {
             return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
         }
 
+        // 검색어 자체를 임베딩해 semantic search용 query vector를 만든다.
         AuctionEmbeddingResult embeddingResult = auctionEmbeddingClient.createEmbedding(request.getQ().trim());
 
+        // Supabase pgvector에서 유사한 경매 후보 ID 집합을 먼저 조회한다.
         List<AuctionQueryEmbeddingMatch> matches = auctionPredictionSupabaseClient.matchAuctionQueryEmbeddings(
                 embeddingResult.getEmbedding(),
                 SEMANTIC_SEARCH_TOP_K,
@@ -98,6 +101,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
             return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
         }
 
+        // 최종 결과는 MariaDB 기준으로 다시 읽고, 진행 중 경매만 최신순으로 정렬한다.
         RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
         List<AuctionListResponse> list = auctionMapper.findAuctionListByAuctionIds(rowBounds, auctionIds, AuctionStatus.ON_GOING);
         int count = auctionMapper.countAuctionListByAuctionIds(auctionIds, AuctionStatus.ON_GOING);

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -6,7 +6,11 @@ import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
 import com.biddingmate.biddinggo.auction.dto.AuctionSemanticSearchRequest;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.AuctionStatus;
+import com.biddingmate.biddinggo.auction.prediction.client.AuctionEmbeddingClient;
+import com.biddingmate.biddinggo.auction.prediction.client.AuctionPredictionSupabaseClient;
+import com.biddingmate.biddinggo.auction.prediction.model.AuctionEmbeddingResult;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionPricePredictionQuery;
+import com.biddingmate.biddinggo.auction.prediction.model.AuctionQueryEmbeddingMatch;
 import com.biddingmate.biddinggo.auction.prediction.service.AuctionPricePredictionService;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
@@ -30,10 +34,14 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
     private static final String SORT_BY_WISH_COUNT = "WISH_COUNT";
     private static final String SORT_BY_POPULARITY = "POPULARITY";
     private static final String SORT_BY_PRICE = "PRICE";
+    private static final int SEMANTIC_SEARCH_TOP_K = 100;
+    private static final double SEMANTIC_SEARCH_MIN_SIMILARITY = 0.45d;
 
     private final AuctionMapper auctionMapper;
     private final ItemImageMapper itemImageMapper;
     private final AuctionPricePredictionService auctionPricePredictionService;
+    private final AuctionEmbeddingClient auctionEmbeddingClient;
+    private final AuctionPredictionSupabaseClient auctionPredictionSupabaseClient;
 
     @Override
     @Transactional(readOnly = true)
@@ -64,7 +72,37 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
     @Transactional(readOnly = true)
     public PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request) {
         validateSortOrder(request.getOrder());
-        return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
+
+        if (!auctionEmbeddingClient.isEnabled() || !auctionPredictionSupabaseClient.isEnabled()) {
+            return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
+        }
+
+        AuctionEmbeddingResult embeddingResult = auctionEmbeddingClient.createEmbedding(request.getQ().trim());
+
+        List<AuctionQueryEmbeddingMatch> matches = auctionPredictionSupabaseClient.matchAuctionQueryEmbeddings(
+                embeddingResult.getEmbedding(),
+                SEMANTIC_SEARCH_TOP_K,
+                SEMANTIC_SEARCH_MIN_SIMILARITY
+        );
+
+        if (matches == null || matches.isEmpty()) {
+            return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
+        }
+
+        List<Long> auctionIds = matches.stream()
+                .map(AuctionQueryEmbeddingMatch::getAuctionId)
+                .distinct()
+                .toList();
+
+        if (auctionIds.isEmpty()) {
+            return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
+        }
+
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        List<AuctionListResponse> list = auctionMapper.findAuctionListByAuctionIds(rowBounds, auctionIds, AuctionStatus.ON_GOING);
+        int count = auctionMapper.countAuctionListByAuctionIds(auctionIds, AuctionStatus.ON_GOING);
+
+        return PageResponse.of(list, request.getPage(), request.getSize(), count);
     }
 
     private void validateSortOrder(String order) {

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -72,6 +72,8 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
     @Transactional(readOnly = true)
     public PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request) {
         validateSortOrder(request.getOrder());
+        String sortBy = parseSortBy(request.getSortBy());
+        String sortOrder = request.getOrder().toUpperCase();
 
         // 외부 임베딩/Supabase 검색이 꺼져 있으면 빈 결과로 처리한다.
         if (!auctionEmbeddingClient.isEnabled() || !auctionPredictionSupabaseClient.isEnabled()) {
@@ -101,9 +103,15 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
             return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
         }
 
-        // 최종 결과는 MariaDB 기준으로 다시 읽고, 진행 중 경매만 최신순으로 정렬한다.
+        // 최종 결과는 MariaDB 기준으로 다시 읽고, 기존 목록 정렬 규칙을 그대로 적용한다.
         RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
-        List<AuctionListResponse> list = auctionMapper.findAuctionListByAuctionIds(rowBounds, auctionIds, AuctionStatus.ON_GOING);
+        List<AuctionListResponse> list = auctionMapper.findAuctionListByAuctionIds(
+                rowBounds,
+                auctionIds,
+                AuctionStatus.ON_GOING,
+                sortBy,
+                sortOrder
+        );
         int count = auctionMapper.countAuctionListByAuctionIds(auctionIds, AuctionStatus.ON_GOING);
 
         return PageResponse.of(list, request.getPage(), request.getSize(), count);

--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.auction.service;
 import com.biddingmate.biddinggo.auction.dto.AuctionDetailResponse;
 import com.biddingmate.biddinggo.auction.dto.AuctionListRequest;
 import com.biddingmate.biddinggo.auction.dto.AuctionListResponse;
+import com.biddingmate.biddinggo.auction.dto.AuctionSemanticSearchRequest;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.auction.prediction.model.AuctionPricePredictionQuery;
@@ -39,9 +40,7 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
     public PageResponse<AuctionListResponse> getAuctionList(AuctionListRequest request) {
         String order = request.getOrder();
 
-        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
-            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
-        }
+        validateSortOrder(order);
 
         AuctionStatus status = parseAuctionStatus(request.getStatus());
         String sortBy = parseSortBy(request.getSortBy());
@@ -59,6 +58,19 @@ public class AuctionQueryServiceImpl implements AuctionQueryService {
         int count = auctionMapper.countAuctionList(status, request.getSellerId(), request.getCategoryId());
 
         return PageResponse.of(list, request.getPage(), request.getSize(), count);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AuctionListResponse> searchAuctionsBySemantic(AuctionSemanticSearchRequest request) {
+        validateSortOrder(request.getOrder());
+        return PageResponse.of(List.of(), request.getPage(), request.getSize(), 0);
+    }
+
+    private void validateSortOrder(String order) {
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
     }
 
     private AuctionStatus parseAuctionStatus(String status) {

--- a/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
+++ b/src/main/java/com/biddingmate/biddinggo/config/SecurityConfig.java
@@ -70,7 +70,10 @@ public class SecurityConfig {
                                 "/api/v1/payments/virtual-accounts/deposit",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/v1/categories/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/auctions", "/api/v1/auctions/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/auctions",
+                                "/api/v1/auctions/**",
+                                "/api/v1/auctions/search").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/resources/db/supabase/035_match_auction_query_embedding.sql
+++ b/src/main/resources/db/supabase/035_match_auction_query_embedding.sql
@@ -1,5 +1,6 @@
 -- Adjust vector dimension if your embedding model is not 1536.
 -- 검색어 임베딩을 기준으로 유사한 경매 query embedding 후보를 검색하는 함수.
+-- 카테고리 필터와 최종 정렬은 적용하지 않고, 후보 추출만 담당한다.
 create or replace function public.match_auction_query_embedding(
     query_embedding vector(1536),
     match_count integer default 100,
@@ -13,6 +14,8 @@ returns table (
 language sql
 stable
 as $$
+    -- 최종 정렬은 애플리케이션에서 최신순으로 다시 적용하므로,
+    -- 여기서는 유사한 후보를 충분히 뽑아주는 역할만 수행한다.
     select
         aqe.auction_id,
         aqe.item_id,

--- a/src/main/resources/db/supabase/035_match_auction_query_embedding.sql
+++ b/src/main/resources/db/supabase/035_match_auction_query_embedding.sql
@@ -1,0 +1,24 @@
+-- Adjust vector dimension if your embedding model is not 1536.
+-- 검색어 임베딩을 기준으로 유사한 경매 query embedding 후보를 검색하는 함수.
+create or replace function public.match_auction_query_embedding(
+    query_embedding vector(1536),
+    match_count integer default 100,
+    min_similarity double precision default 0
+)
+returns table (
+    auction_id bigint,
+    item_id bigint,
+    category_id bigint
+)
+language sql
+stable
+as $$
+    select
+        aqe.auction_id,
+        aqe.item_id,
+        aqe.category_id
+    from public.auction_query_embedding aqe
+    where 1 - (aqe.embedding <=> query_embedding) >= min_similarity
+    order by aqe.embedding <=> query_embedding
+    limit greatest(match_count, 0);
+$$;

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -204,7 +204,7 @@
     <select id="findAuctionListByAuctionIds" parameterType="map" resultMap="auctionListResultMap">
         <!--
             Supabase semantic search가 뽑은 후보 auction_id 집합을 실제 경매 목록으로 변환한다.
-            최종 노출 조건은 진행 중 경매만 허용하고, 정렬은 최신순으로 고정한다.
+            최종 노출 조건은 진행 중 경매만 허용하고, 정렬은 기존 목록 조회 규칙을 재사용한다.
         -->
         SELECT
             a.id AS auction_id,
@@ -235,7 +235,13 @@
         <if test="status != null">
             AND a.status = #{status}
         </if>
-        ORDER BY a.created_at DESC
+        ORDER BY
+        <choose>
+            <when test='sortBy == "PRICE"'>COALESCE(a.vickrey_price, a.start_price) ${order}, a.created_at DESC</when>
+            <when test='sortBy == "POPULARITY"'>(a.bid_count + a.wish_count) ${order}, a.created_at DESC</when>
+            <when test='sortBy == "WISH_COUNT"'>a.wish_count ${order}, a.created_at DESC</when>
+            <otherwise>a.created_at ${order}</otherwise>
+        </choose>
     </select>
 
     <select id="countAuctionListByAuctionIds" parameterType="map" resultType="_int">

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -202,6 +202,10 @@
     </select>
 
     <select id="findAuctionListByAuctionIds" parameterType="map" resultMap="auctionListResultMap">
+        <!--
+            Supabase semantic search가 뽑은 후보 auction_id 집합을 실제 경매 목록으로 변환한다.
+            최종 노출 조건은 진행 중 경매만 허용하고, 정렬은 최신순으로 고정한다.
+        -->
         SELECT
             a.id AS auction_id,
             ai.id AS item_id,
@@ -235,6 +239,7 @@
     </select>
 
     <select id="countAuctionListByAuctionIds" parameterType="map" resultType="_int">
+        <!-- semantic search 후보 집합 중 실제로 노출 가능한 경매 수를 센다. -->
         SELECT COUNT(*)
         FROM auction a
         WHERE a.id IN

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -214,7 +214,7 @@
             a.bid_count,
             a.wish_count,
             a.end_date,
-            ii.image_url AS representative_image_url,
+            ii.url AS representative_image_url,
             a.created_at
         FROM auction a
         INNER JOIN auction_item ai ON a.item_id = ai.id

--- a/src/main/resources/mapper/auction/auction-mapper.xml
+++ b/src/main/resources/mapper/auction/auction-mapper.xml
@@ -201,6 +201,51 @@
         </if>
     </select>
 
+    <select id="findAuctionListByAuctionIds" parameterType="map" resultMap="auctionListResultMap">
+        SELECT
+            a.id AS auction_id,
+            ai.id AS item_id,
+            ai.brand,
+            ai.name,
+            a.status,
+            a.type,
+            a.start_price,
+            a.buy_now_price,
+            a.bid_count,
+            a.wish_count,
+            a.end_date,
+            ii.image_url AS representative_image_url,
+            a.created_at
+        FROM auction a
+        INNER JOIN auction_item ai ON a.item_id = ai.id
+        LEFT JOIN item_image ii ON ii.item_id = ai.id
+            AND ii.display_order = (
+                SELECT MIN(ii2.display_order)
+                FROM item_image ii2
+                WHERE ii2.item_id = ai.id
+            )
+        WHERE a.id IN
+        <foreach collection="auctionIds" item="auctionId" open="(" separator="," close=")">
+            #{auctionId}
+        </foreach>
+        <if test="status != null">
+            AND a.status = #{status}
+        </if>
+        ORDER BY a.created_at DESC
+    </select>
+
+    <select id="countAuctionListByAuctionIds" parameterType="map" resultType="_int">
+        SELECT COUNT(*)
+        FROM auction a
+        WHERE a.id IN
+        <foreach collection="auctionIds" item="auctionId" open="(" separator="," close=")">
+            #{auctionId}
+        </foreach>
+        <if test="status != null">
+            AND a.status = #{status}
+        </if>
+    </select>
+
     <select id="findById" parameterType="long" resultType="com.biddingmate.biddinggo.auction.model.Auction">
         SELECT id,
                item_id AS itemId,

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -461,7 +461,6 @@
         SET status = #{status}
         WHERE id = #{memberId}
     </update>
-</mapper>
 
     <!-- 판매중인 경매 존재 여부 -->
     <select id="existsOngoingSales" parameterType="long" resultType="boolean">


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 검색어를 임베딩해 Supabase pgvector에서 유사한 경매 후보를 조회하는 경로를 추가했습니다.
- Supabase 후보 `auctionId`를 기반으로 MariaDB에서 진행 중 경매를 조회하는 semantic search 흐름을 구현했습니다.
- `GET /api/v1/auctions/search/semantic` 검색 API와 요청 DTO를 추가했습니다.
- 검색 결과 정렬은 기존 경매 목록의 `sortBy`, `order` 규칙을 재사용하도록 적용했습니다.
- Supabase 검색용 RPC 함수 초안과 관련 client/model/mapper 코드를 추가했습니다.
- 관련 코드에 검색 흐름 설명 주석을 보완했습니다.

---

## 📎 관련 이슈

-close #85
