### PR TITLE
feat: 구매자 배송지 등록 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/address/dto/CreateAddressRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/address/dto/CreateAddressRequest.java
@@ -2,6 +2,7 @@ package com.biddingmate.biddinggo.address.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +14,15 @@ import lombok.Getter;
 public class CreateAddressRequest {
     @Schema(description = "우편번호", example = "06236")
     @NotBlank(message = "우편번호는 필수입니다.")
+    @Size(max = 20, message = "우편번호는 20자 이하여야 합니다.")
     private String zipcode;
 
     @Schema(description = "기본 주소", example = "서울특별시 강남구 테헤란로 123")
     @NotBlank(message = "주소는 필수입니다.")
+    @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
     private String address;
 
     @Schema(description = "상세 주소", example = "101동 202호", nullable = true)
+    @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
     private String detailAddress;
 }

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -132,6 +132,9 @@ public enum ErrorType {
     WINNER_DEAL_UPDATE_FAILED("winner-deal-002", "낙찰 거래 상태 변경에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     WINNER_DEAL_NOT_FOUND("winner-deal-003", "해당 경매에 대한 낙찰 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     WINNER_DEAL_ACCESS_DENIED("winner-deal-004", "본인의 낙찰 거래만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    WINNER_DEAL_SHIPPING_ADDRESS_ACCESS_DENIED("winner-deal-005", "낙찰 거래의 구매자만 배송지 정보를 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
+    WINNER_DEAL_SHIPPING_ADDRESS_REGISTRATION_NOT_ALLOWED("winner-deal-006", "현재 상태의 낙찰 거래에는 배송지 정보를 등록할 수 없습니다.", HttpStatus.CONFLICT),
+    WINNER_DEAL_SHIPPING_ADDRESS_SAVE_FAILED("winner-deal-007", "낙찰 거래 배송지 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 리뷰
     REVIEW_SAVE_FAIL("review-001", "리뷰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/biddingmate/biddinggo/notice/controller/AdminNoticeController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admins/notices")
 @PreAuthorize("hasRole('ADMIN')")
-@Tag(name = "Admin-notice", description = "공지사항")
+@Tag(name = "Admin-Notice", description = "공지사항")
 public class AdminNoticeController {
 
     private final AdminNoticeService adminNoticeService;

--- a/src/main/java/com/biddingmate/biddinggo/notice/controller/NoticeController.java
+++ b/src/main/java/com/biddingmate/biddinggo/notice/controller/NoticeController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notices")
-@Tag(name = "user-notice", description = "유저 공지사항")
+@Tag(name = "User-Notice", description = "유저 공지사항")
 public class NoticeController {
 
     private final NoticeService noticeService;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
@@ -3,7 +3,7 @@ package com.biddingmate.biddinggo.winnerdeal.controller;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.model.Member;
-import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
@@ -62,7 +62,7 @@ public class WinnerDealController {
     @PatchMapping("/{winnerDealId}/shipping-address")
     @Operation(summary = "낙찰 거래 배송지 등록", description = "구매자가 낙찰 거래에 배송지 정보를 등록합니다.")
     public ResponseEntity<ApiResponse<Void>> registerShippingAddress(@Parameter(description = "낙찰 거래 ID", example = "1") @PathVariable Long winnerDealId,
-                                                                     @Valid @RequestBody RegisterWinnerDealShippingAddressRequest request,
+                                                                     @Valid @RequestBody WinnerDealShippingAddressRequest request,
                                                                      @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
         winnerDealService.registerShippingAddress(winnerDealId, member.getId(), request);
 

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
@@ -3,10 +3,12 @@ package com.biddingmate.biddinggo.winnerdeal.controller;
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.model.Member;
+import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
 import com.biddingmate.biddinggo.winnerdeal.service.WinnerDealQueryService;
+import com.biddingmate.biddinggo.winnerdeal.service.WinnerDealService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,7 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,9 +30,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Winner-Deal", description = "낙찰 거래 관리 API")
 public class WinnerDealController {
     private final WinnerDealQueryService winnerDealQueryService;
+    private final WinnerDealService winnerDealService;
 
-    @Operation(summary = "구매 내역 조회", description = "로그인한 사용자의 낙찰 거래 구매 내역을 상태별 필터와 함께 조회합니다.")
     @GetMapping("/purchases")
+    @Operation(summary = "구매 내역 조회", description = "로그인한 사용자의 낙찰 거래 구매 내역을 상태별 필터와 함께 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<WinnerDealHistoryResponse>>> findPurchaseHistory(@Valid WinnerDealHistoryRequest request,
                                                                                                     @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
         PageResponse<WinnerDealHistoryResponse> result = winnerDealQueryService.findPurchaseHistory(request, member.getId());
@@ -36,8 +41,8 @@ public class WinnerDealController {
         return ApiResponse.of(HttpStatus.OK, null, "구매 내역 조회에 성공했습니다.", result);
     }
 
-    @Operation(summary = "판매 내역 조회", description = "로그인한 사용자의 낙찰 거래 판매 내역을 상태별 필터와 함께 조회합니다.")
     @GetMapping("/sales")
+    @Operation(summary = "판매 내역 조회", description = "로그인한 사용자의 낙찰 거래 판매 내역을 상태별 필터와 함께 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<WinnerDealHistoryResponse>>> findSaleHistory(@Valid WinnerDealHistoryRequest request,
                                                                                                 @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
         PageResponse<WinnerDealHistoryResponse> result = winnerDealQueryService.findSaleHistory(request, member.getId());
@@ -45,12 +50,22 @@ public class WinnerDealController {
         return ApiResponse.of(HttpStatus.OK, null, "판매 내역 조회에 성공했습니다.", result);
     }
 
-    @Operation(summary = "거래 내역 상세 조회", description = "로그인한 사용자의 낙찰 거래 상세 정보를 조회합니다.")
     @GetMapping("/{winnerDealId}")
+    @Operation(summary = "거래 내역 상세 조회", description = "로그인한 사용자의 낙찰 거래 상세 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<WinnerDealDetailResponse>> findWinnerDealDetail(@Parameter(description = "낙찰 ID", example = "1") @PathVariable Long winnerDealId,
                                                                                       @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
         WinnerDealDetailResponse result = winnerDealQueryService.findWinnerDealDetail(winnerDealId, member.getId());
 
         return ApiResponse.of(HttpStatus.OK, null, "낙찰 거래 상세 조회에 성공했습니다.", result);
+    }
+
+    @PatchMapping("/{winnerDealId}/shipping-address")
+    @Operation(summary = "낙찰 거래 배송지 등록", description = "구매자가 낙찰 거래에 배송지 정보를 등록합니다.")
+    public ResponseEntity<ApiResponse<Void>> registerShippingAddress(@Parameter(description = "낙찰 거래 ID", example = "1") @PathVariable Long winnerDealId,
+                                                                     @Valid @RequestBody RegisterWinnerDealShippingAddressRequest request,
+                                                                     @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
+        winnerDealService.registerShippingAddress(winnerDealId, member.getId(), request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "낙찰 거래 배송지 정보 등록에 성공했습니다.", null);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/RegisterWinnerDealShippingAddressRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/RegisterWinnerDealShippingAddressRequest.java
@@ -1,0 +1,42 @@
+package com.biddingmate.biddinggo.winnerdeal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "낙찰 거래 배송지 등록 요청 DTO")
+public class RegisterWinnerDealShippingAddressRequest {
+    @Schema(description = "우편번호", example = "06109")
+    @NotBlank(message = "우편번호는 필수입니다.")
+    @Size(max = 20, message = "우편번호는 20자 이하여야 합니다.")
+    private String zipcode;
+
+    @Schema(description = "기본 주소", example = "서울 강남구 테헤란로 152")
+    @NotBlank(message = "주소는 필수입니다.")
+    @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+    private String address;
+
+    @Schema(description = "상세 주소", example = "강남파이낸스센터 12층")
+    @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
+    private String detailAddress;
+
+    @Schema(description = "수령인", example = "홍길동")
+    @NotBlank(message = "수령인은 필수입니다.")
+    @Size(max = 20, message = "수령인은 20자 이하여야 합니다.")
+    private String recipient;
+
+    @Schema(description = "연락처", example = "010-1234-5678")
+    @NotBlank(message = "연락처는 필수입니다.")
+    @Size(max = 20, message = "연락처는 20자 이하여야 합니다.")
+    private String tel;
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealShippingAddressRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealShippingAddressRequest.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @Schema(description = "낙찰 거래 배송지 등록 요청 DTO")
-public class RegisterWinnerDealShippingAddressRequest {
+public class WinnerDealShippingAddressRequest {
     @Schema(description = "우편번호", example = "06109")
     @NotBlank(message = "우편번호는 필수입니다.")
     @Size(max = 20, message = "우편번호는 20자 이하여야 합니다.")

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -2,7 +2,7 @@ package com.biddingmate.biddinggo.winnerdeal.mapper;
 
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
-import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
 import org.apache.ibatis.annotations.Mapper;
@@ -41,5 +41,5 @@ public interface WinnerDealMapper {
 
     // 구매자의 배송지 등록
     int updateShippingAddress(@Param("winnerDealId") Long winnerDealId,
-                              @Param("request") RegisterWinnerDealShippingAddressRequest request);
+                              @Param("request") WinnerDealShippingAddressRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -2,6 +2,7 @@ package com.biddingmate.biddinggo.winnerdeal.mapper;
 
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
 import org.apache.ibatis.annotations.Mapper;
@@ -13,6 +14,7 @@ import java.util.List;
 @Mapper
 public interface WinnerDealMapper {
     int insert(WinnerDeal winnerDeal);
+    WinnerDeal findById(Long id);
     WinnerDeal findByAuctionId(Long auctionId);
 
     List<WinnerDeal> findByMemberId(@Param("memberId") Long memberId);
@@ -34,5 +36,10 @@ public interface WinnerDealMapper {
     long countSaleHistory(@Param("request") WinnerDealHistoryRequest request,
                           @Param("memberId") Long memberId);
 
+    // 거래 내역 상세 조회
     WinnerDealDetailQueryResult findWinnerDealDetail(@Param("winnerDealId") Long winnerDealId);
+
+    // 구매자의 배송지 등록
+    int updateShippingAddress(@Param("winnerDealId") Long winnerDealId,
+                              @Param("request") RegisterWinnerDealShippingAddressRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -130,6 +130,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
     }
 
     private boolean isShippingAddressRegistered(WinnerDealDetailQueryResult detail) {
+        // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
         return StringUtils.hasText(detail.getRecipient())
                 && StringUtils.hasText(detail.getTel())
                 && StringUtils.hasText(detail.getZipcode())
@@ -137,6 +138,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
     }
 
     private boolean isTrackingNumberRegistered(WinnerDealDetailQueryResult detail) {
+        // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
         return StringUtils.hasText(detail.getCarrier())
                 && StringUtils.hasText(detail.getTrackingNumber());
     }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -133,8 +133,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
         return StringUtils.hasText(detail.getRecipient())
                 && StringUtils.hasText(detail.getTel())
                 && StringUtils.hasText(detail.getZipcode())
-                && StringUtils.hasText(detail.getAddress())
-                && StringUtils.hasText(detail.getDetailAddress());
+                && StringUtils.hasText(detail.getAddress());
     }
 
     private boolean isTrackingNumberRegistered(WinnerDealDetailQueryResult detail) {

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
@@ -1,12 +1,12 @@
 package com.biddingmate.biddinggo.winnerdeal.service;
 
 import com.biddingmate.biddinggo.auction.model.Auction;
-import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 
 public interface WinnerDealService {
     void processClosing(Auction auction);
     void handleMemberDeactivationAfterWinning(Long memberId);
 
     // 구매자 배송지 등록
-    void registerShippingAddress(Long winnerDealId, Long memberId, RegisterWinnerDealShippingAddressRequest request);
+    void registerShippingAddress(Long winnerDealId, Long memberId, WinnerDealShippingAddressRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
@@ -1,12 +1,12 @@
 package com.biddingmate.biddinggo.winnerdeal.service;
 
 import com.biddingmate.biddinggo.auction.model.Auction;
-import com.biddingmate.biddinggo.common.response.PageResponse;
-import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
-import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
-import jakarta.validation.Valid;
+import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
 
 public interface WinnerDealService {
     void processClosing(Auction auction);
     void handleMemberDeactivationAfterWinning(Long memberId);
+
+    // 구매자 배송지 등록
+    void registerShippingAddress(Long winnerDealId, Long memberId, RegisterWinnerDealShippingAddressRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -14,7 +14,7 @@ import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.point.service.PointService;
-import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
 import lombok.RequiredArgsConstructor;
@@ -144,7 +144,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
 
     @Override
     @Transactional
-    public void registerShippingAddress(Long winnerDealId, Long memberId, RegisterWinnerDealShippingAddressRequest request) {
+    public void registerShippingAddress(Long winnerDealId, Long memberId, WinnerDealShippingAddressRequest request) {
         WinnerDeal winnerDeal = winnerDealMapper.findById(winnerDealId);
 
         if (winnerDeal == null) {
@@ -156,10 +156,10 @@ public class WinnerDealServiceImpl implements WinnerDealService {
             throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_ACCESS_DENIED);
         }
 
-        // 배송지 또는 송장 정보가 이미 있거나 PAID 상태가 아닌 경우
+        // 배송지 또는 운송장 정보가 이미 있거나 PAID 상태가 아닌 경우
         if (!"PAID".equals(winnerDeal.getStatus())
-                || StringUtils.hasText(winnerDeal.getTrackingNumber())
-                || isShippingInfoRegistered(winnerDeal)) {
+                || isShippingInfoRegistered(winnerDeal)
+                || isTrackingNumberRegistered(winnerDeal)) {
             throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_REGISTRATION_NOT_ALLOWED);
         }
 
@@ -207,5 +207,11 @@ public class WinnerDealServiceImpl implements WinnerDealService {
                 && StringUtils.hasText(winnerDeal.getTel())
                 && StringUtils.hasText(winnerDeal.getZipcode())
                 && StringUtils.hasText(winnerDeal.getAddress());
+    }
+
+    private boolean isTrackingNumberRegistered(WinnerDeal winnerDeal) {
+        // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
+        return StringUtils.hasText(winnerDeal.getCarrier())
+                && StringUtils.hasText(winnerDeal.getTrackingNumber());
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -10,13 +10,11 @@ import com.biddingmate.biddinggo.bid.mapper.BidMapper;
 import com.biddingmate.biddinggo.bid.service.BidQueryService;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
-import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.point.service.PointService;
-import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
-import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.RegisterWinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
 import lombok.RequiredArgsConstructor;
@@ -144,13 +142,31 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         log.info("낙찰 후 비활성화 대상 거래 수 - Member ID: {}, Count: {}", memberId, winnerDeals.size());
     }
 
-    private boolean isShippingInfoRegistered(WinnerDeal winnerDeal) {
-        // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
-        return StringUtils.hasText(winnerDeal.getRecipient())
-                && StringUtils.hasText(winnerDeal.getTel())
-                && StringUtils.hasText(winnerDeal.getZipcode())
-                && StringUtils.hasText(winnerDeal.getAddress())
-                && StringUtils.hasText(winnerDeal.getDetailAddress());
+    @Override
+    @Transactional
+    public void registerShippingAddress(Long winnerDealId, Long memberId, RegisterWinnerDealShippingAddressRequest request) {
+        WinnerDeal winnerDeal = winnerDealMapper.findById(winnerDealId);
+
+        if (winnerDeal == null) {
+            throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
+        }
+
+        // 구매자가 아닌 경우
+        if (!winnerDeal.getWinnerId().equals(memberId)) {
+            throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_ACCESS_DENIED);
+        }
+
+        // 배송지 또는 송장 정보가 이미 있거나 PAID 상태가 아닌 경우
+        if (!"PAID".equals(winnerDeal.getStatus())
+                || StringUtils.hasText(winnerDeal.getTrackingNumber())
+                || isShippingInfoRegistered(winnerDeal)) {
+            throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_REGISTRATION_NOT_ALLOWED);
+        }
+
+        int updatedRows = winnerDealMapper.updateShippingAddress(winnerDealId, request);
+        if (updatedRows != 1) {
+            throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_SAVE_FAILED);
+        }
     }
 
     private void refundAndCancelWinnerDeal(WinnerDeal winnerDeal) {
@@ -183,5 +199,13 @@ public class WinnerDealServiceImpl implements WinnerDealService {
                 .winnerPrice(winnerPrice)
                 .completedAt(LocalDateTime.now())
                 .build());
+    }
+
+    private boolean isShippingInfoRegistered(WinnerDeal winnerDeal) {
+        // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
+        return StringUtils.hasText(winnerDeal.getRecipient())
+                && StringUtils.hasText(winnerDeal.getTel())
+                && StringUtils.hasText(winnerDeal.getZipcode())
+                && StringUtils.hasText(winnerDeal.getAddress());
     }
 }

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -22,6 +22,28 @@
                      #{createdAt}
                  )
     </insert>
+    <select id="findById" resultType="WinnerDeal">
+        SELECT
+            id,
+            auction_id AS auctionId,
+            winner_id AS winnerId,
+            seller_id AS sellerId,
+            winner_price AS winnerPrice,
+            status,
+            delivery_status AS deliveryStatus,
+            confirmed_at AS confirmedAt,
+            zipcode,
+            address,
+            detail_address AS detailAddress,
+            tel,
+            recipient,
+            carrier,
+            tracking_number AS trackingNumber,
+            created_at AS createdAt
+        FROM winner_deal
+        WHERE id = #{id}
+        LIMIT 1
+    </select>
     <select id="findByAuctionId" resultType="WinnerDeal">
         SELECT
             id,
@@ -202,5 +224,16 @@
         WHERE wd.id = #{winnerDealId}
         LIMIT 1
     </select>
+
+    <!-- 구매자의 배송지 등록 -->
+    <update id="updateShippingAddress">
+        UPDATE winner_deal
+        SET zipcode = #{request.zipcode},
+            address = #{request.address},
+            detail_address = #{request.detailAddress},
+            tel = #{request.tel},
+            recipient = #{request.recipient}
+        WHERE id = #{winnerDealId}
+    </update>
 
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 구매자가 낙찰 거래에 배송지 정보를 등록할 수 있는 API를 추가했습니다.
- 배송지 등록 요청 DTO를 추가하고 zipcode, address, detailAddress, recipient, tel 값으로 구성했습니다.
- 로그인 사용자가 해당 낙찰 거래의 구매자인지 검증하도록 처리했습니다.
- 낙찰 거래가 존재하지 않는 경우, 구매자가 아닌 경우, 배송지 등록이 불가능한 상태인 경우에 대한 예외 처리를 추가했습니다.
- winner_deal 테이블의 배송지 관련 컬럼을 업데이트하는 MyBatis 매퍼 로직을 추가했습니다.
- 상세주소가 nullable인 현재 구조에 맞게 배송지 등록 여부 판정 로직을 보정했습니다.

---

## 📎 관련 이슈
- #181 