### PR TITLE
feat: 판매자 운송장 등록 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -135,6 +135,9 @@ public enum ErrorType {
     WINNER_DEAL_SHIPPING_ADDRESS_ACCESS_DENIED("winner-deal-005", "낙찰 거래의 구매자만 배송지 정보를 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
     WINNER_DEAL_SHIPPING_ADDRESS_REGISTRATION_NOT_ALLOWED("winner-deal-006", "현재 상태의 낙찰 거래에는 배송지 정보를 등록할 수 없습니다.", HttpStatus.CONFLICT),
     WINNER_DEAL_SHIPPING_ADDRESS_SAVE_FAILED("winner-deal-007", "낙찰 거래 배송지 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    WINNER_DEAL_TRACKING_NUMBER_ACCESS_DENIED("winner-deal-008", "낙찰 거래의 판매자만 운송장 정보를 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
+    WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED("winner-deal-009", "현재 상태의 낙찰 거래에는 운송장 정보를 등록할 수 없습니다.", HttpStatus.CONFLICT),
+    WINNER_DEAL_TRACKING_NUMBER_SAVE_FAILED("winner-deal-010", "낙찰 거래 운송장 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 리뷰
     REVIEW_SAVE_FAIL("review-001", "리뷰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
@@ -4,6 +4,7 @@ import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
@@ -67,5 +68,14 @@ public class WinnerDealController {
         winnerDealService.registerShippingAddress(winnerDealId, member.getId(), request);
 
         return ApiResponse.of(HttpStatus.OK, null, "낙찰 거래 배송지 정보 등록에 성공했습니다.", null);
+    }
+    @PatchMapping("/{winnerDealId}/tracking-number")
+    @Operation(summary = "낙찰 거래 운송장 등록", description = "판매자가 낙찰 거래에 운송장 정보를 등록합니다.")
+    public ResponseEntity<ApiResponse<Void>> registerTrackingNumber(@Parameter(description = "낙찰 거래 ID", example = "1") @PathVariable Long winnerDealId,
+                                                                    @Valid @RequestBody WinnerDealTrackingNumberRequest request,
+                                                                    @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
+        winnerDealService.registerTrackingNumber(winnerDealId, member.getId(), request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "낙찰 거래 운송장 정보 등록에 성공했습니다.", null);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealTrackingNumberRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealTrackingNumberRequest.java
@@ -1,0 +1,28 @@
+package com.biddingmate.biddinggo.winnerdeal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "낙찰 거래 운송장 등록 요청 DTO")
+public class WinnerDealTrackingNumberRequest {
+    @Schema(description = "택배사", example = "CJ대한통운")
+    @NotBlank(message = "택배사는 필수입니다.")
+    @Size(max = 20, message = "택배사는 20자 이하여야 합니다.")
+    private String carrier;
+
+    @Schema(description = "운송장 번호", example = "1234567890")
+    @NotBlank(message = "운송장 번호는 필수입니다.")
+    @Size(max = 30, message = "운송장 번호는 30자 이하여야 합니다.")
+    private String trackingNumber;
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -3,6 +3,7 @@ package com.biddingmate.biddinggo.winnerdeal.mapper;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
 import org.apache.ibatis.annotations.Mapper;
@@ -42,4 +43,7 @@ public interface WinnerDealMapper {
     // 구매자의 배송지 등록
     int updateShippingAddress(@Param("winnerDealId") Long winnerDealId,
                               @Param("request") WinnerDealShippingAddressRequest request);
+
+    int updateTrackingNumber(@Param("winnerDealId") Long winnerDealId,
+                             @Param("request") WinnerDealTrackingNumberRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
@@ -2,6 +2,7 @@ package com.biddingmate.biddinggo.winnerdeal.service;
 
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 
 public interface WinnerDealService {
     void processClosing(Auction auction);
@@ -9,4 +10,6 @@ public interface WinnerDealService {
 
     // 구매자 배송지 등록
     void registerShippingAddress(Long winnerDealId, Long memberId, WinnerDealShippingAddressRequest request);
+    // 판매자 운송장 번호 등록
+    void registerTrackingNumber(Long winnerDealId, Long memberId, WinnerDealTrackingNumberRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -15,6 +15,7 @@ import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.point.service.PointService;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
 import lombok.RequiredArgsConstructor;
@@ -166,6 +167,33 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         int updatedRows = winnerDealMapper.updateShippingAddress(winnerDealId, request);
         if (updatedRows != 1) {
             throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_SAVE_FAILED);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void registerTrackingNumber(Long winnerDealId, Long memberId, WinnerDealTrackingNumberRequest request) {
+        WinnerDeal winnerDeal = winnerDealMapper.findById(winnerDealId);
+
+        if (winnerDeal == null) {
+            throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
+        }
+
+        // 판매자가 아닌 경우
+        if (!winnerDeal.getSellerId().equals(memberId)) {
+            throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_ACCESS_DENIED);
+        }
+
+        // 운송장 등록은 PAID 상태에서 배송지 정보가 있고 아직 운송장 정보가 없을 때만 허용한다.
+        if (!"PAID".equals(winnerDeal.getStatus())
+                || !isShippingInfoRegistered(winnerDeal)
+                || isTrackingNumberRegistered(winnerDeal)) {
+            throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED);
+        }
+
+        int updatedRows = winnerDealMapper.updateTrackingNumber(winnerDealId, request);
+        if (updatedRows != 1) {
+            throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_SAVE_FAILED);
         }
     }
 

--- a/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
+++ b/src/main/resources/mapper/auction-inquiry/auction-inquiry-mapper.xml
@@ -46,9 +46,12 @@
     <update id="updateAnswer" parameterType="AuctionInquiry">
         UPDATE auction_inquiry
         SET answer      = #{answer},
-            answerer_id = #{answererId}, answered_at = #{answeredAt},
-            status      = #{status}      WHERE id = #{id}
-                                           AND status = 'PENDING'         </update>
+            answerer_id = #{answererId},
+            answered_at = #{answeredAt},
+            status      = #{status}
+        WHERE id = #{id}
+          AND status = 'PENDING'
+    </update>
 
     <select id="selectInquiryList" resultType="AuctionInquiryView">
         SELECT
@@ -73,7 +76,6 @@
         FROM auction_inquiry
         WHERE auction_id = #{auctionId}
     </select>
-<<<<<<< feat/member-inquiry-history-c
 
     <select id="findMyAuctionInquiries" resultType="MemberAuctionInquiryResponse">
         SELECT
@@ -154,6 +156,4 @@
         </where>
     </select>
 </mapper>
-=======
-</mapper>
->>>>>>> dev
+

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -236,4 +236,12 @@
         WHERE id = #{winnerDealId}
     </update>
 
+    <!-- 판매자의 운송장 등록 -->
+    <update id="updateTrackingNumber">
+        UPDATE winner_deal
+        SET carrier = #{request.carrier},
+            tracking_number = #{request.trackingNumber}
+        WHERE id = #{winnerDealId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 판매자가 낙찰 거래에 운송장 정보를 등록할 수 있는 API를 추가했습니다.
- 로그인 사용자가 해당 낙찰 거래의 판매자인지 검증하도록 처리했습니다.
- 배송지 정보가 등록된 거래에서만 운송장 등록이 가능하도록 검증 로직을 추가했습니다.
- 이미 운송장 정보가 등록된 경우와 등록이 불가능한 거래 상태에 대한 예외 처리를 추가했습니다.
- winner_deal 테이블의 carrier, tracking_number를 갱신하는 MyBatis 매퍼 로직을 추가했습니다.
- 운송장 등록 전용 ErrorType을 추가해 예외 상황을 명확히 구분했습니다.
---

## 📎 관련 이슈
- #190 
