### PR TITLE
feat: 구매자 구매확정 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -138,6 +138,10 @@ public enum ErrorType {
     WINNER_DEAL_TRACKING_NUMBER_ACCESS_DENIED("winner-deal-008", "낙찰 거래의 판매자만 운송장 정보를 등록할 수 있습니다.", HttpStatus.FORBIDDEN),
     WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED("winner-deal-009", "현재 상태의 낙찰 거래에는 운송장 정보를 등록할 수 없습니다.", HttpStatus.CONFLICT),
     WINNER_DEAL_TRACKING_NUMBER_SAVE_FAILED("winner-deal-010", "낙찰 거래 운송장 정보 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    WINNER_DEAL_CONFIRM_ACCESS_DENIED("winner-deal-011", "낙찰 거래의 구매자만 구매확정을 할 수 있습니다.", HttpStatus.FORBIDDEN),
+    WINNER_DEAL_CONFIRM_NOT_ALLOWED("winner-deal-012", "현재 상태의 낙찰 거래는 구매확정을 할 수 없습니다.", HttpStatus.CONFLICT),
+    WINNER_DEAL_CONFIRM_FAILED("winner-deal-013", "낙찰 거래 구매확정 처리에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    WINNER_DEAL_SETTLEMENT_INVALID("winner-deal-014", "낙찰 거래 정산 정보가 올바르지 않습니다.", HttpStatus.CONFLICT),
 
     // 리뷰
     REVIEW_SAVE_FAIL("review-001", "리뷰 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/point/model/PointHistoryType.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/model/PointHistoryType.java
@@ -4,5 +4,6 @@ public enum PointHistoryType {
     CHARGE,
     BID,
     EXCHANGE,
-    REFUND
+    REFUND,
+    SETTLEMENT
 }

--- a/src/main/java/com/biddingmate/biddinggo/point/service/PointService.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/service/PointService.java
@@ -13,6 +13,7 @@ public interface PointService {
     MyPointResponse findMyPointList(BasePageRequest request, Long memberId);
     void exchangePoint(ExchangePointRequest request, Long memberId);
     void refundBid(Long bidderId, Long amount);
+    void settleWinnerDeal(Long sellerId, Long amount);
 
     // 취소된 경매의 입찰 참여자들 환불
     void refundBidsByAuctionIds(List<Long> auctionIds);

--- a/src/main/java/com/biddingmate/biddinggo/point/service/PointServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/point/service/PointServiceImpl.java
@@ -99,6 +99,24 @@ public class PointServiceImpl implements PointService {
 
     @Override
     @Transactional
+    public void settleWinnerDeal(Long sellerId, Long amount) {
+        memberService.addPoint(sellerId, amount);
+
+        PointHistory pointHistory = PointHistory.builder()
+                .memberId(sellerId)
+                .type(PointHistoryType.SETTLEMENT)
+                .amount(amount)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        int settlement = this.addPointHistory(pointHistory);
+        if (settlement != 1) {
+            throw new CustomException(ErrorType.POINT_HISTORY_SAVE_FAILED);
+        }
+    }
+
+    @Override
+    @Transactional
     public void refundBidsByAuctionIds(List<Long> auctionIds) {
         // 1. 해당 경매들 입찰 전체 조회
         List<RefundDto> refunds = bidQueryService.findByAuctionIds(auctionIds);

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/WinnerDealController.java
@@ -78,4 +78,12 @@ public class WinnerDealController {
 
         return ApiResponse.of(HttpStatus.OK, null, "낙찰 거래 운송장 정보 등록에 성공했습니다.", null);
     }
+    @PatchMapping("/{winnerDealId}/confirm")
+    @Operation(summary = "낙찰 거래 구매확정", description = "구매자가 낙찰 거래를 구매확정 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> confirmPurchase(@Parameter(description = "낙찰 거래 ID", example = "1") @PathVariable Long winnerDealId,
+                                                             @Parameter(hidden = true) @AuthenticationPrincipal Member member) {
+        winnerDealService.confirmPurchase(winnerDealId, member.getId());
+
+        return ApiResponse.of(HttpStatus.OK, null, "낙찰 거래 구매확정에 성공했습니다.", null);
+    }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -46,4 +46,7 @@ public interface WinnerDealMapper {
 
     int updateTrackingNumber(@Param("winnerDealId") Long winnerDealId,
                              @Param("request") WinnerDealTrackingNumberRequest request);
+
+    int confirmPurchase(@Param("winnerDealId") Long winnerDealId,
+                        @Param("confirmedAt") java.time.LocalDateTime confirmedAt);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
@@ -12,4 +12,6 @@ public interface WinnerDealService {
     void registerShippingAddress(Long winnerDealId, Long memberId, WinnerDealShippingAddressRequest request);
     // 판매자 운송장 번호 등록
     void registerTrackingNumber(Long winnerDealId, Long memberId, WinnerDealTrackingNumberRequest request);
+    // 구매자 구매확정
+    void confirmPurchase(Long winnerDealId, Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -236,6 +236,8 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         } else if (refundAmount > 0) {
             pointService.refundBid(memberId, refundAmount);
         }
+
+        pointService.settleWinnerDeal(winnerDeal.getSellerId(), winnerDeal.getWinnerPrice());
     }
 
     private void refundAndCancelWinnerDeal(WinnerDeal winnerDeal) {

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -7,7 +7,9 @@ import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.auction.prediction.event.AuctionPriceReferenceSyncRequestedEvent;
 import com.biddingmate.biddinggo.bid.dto.BidResponse;
 import com.biddingmate.biddinggo.bid.mapper.BidMapper;
+import com.biddingmate.biddinggo.bid.model.Bid;
 import com.biddingmate.biddinggo.bid.service.BidQueryService;
+import com.biddingmate.biddinggo.bid.service.BidService;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
@@ -35,6 +37,7 @@ import java.util.List;
 public class WinnerDealServiceImpl implements WinnerDealService {
     private final AuctionMapper auctionMapper;
     private final BidMapper bidMapper;
+    private final BidService bidService;
     private final BidQueryService bidQueryService;
     private final WinnerDealMapper winnerDealMapper;
     private final WinnerDealQueryService winnerDealQueryService;
@@ -194,6 +197,44 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         int updatedRows = winnerDealMapper.updateTrackingNumber(winnerDealId, request);
         if (updatedRows != 1) {
             throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_SAVE_FAILED);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void confirmPurchase(Long winnerDealId, Long memberId) {
+        WinnerDeal winnerDeal = winnerDealMapper.findById(winnerDealId);
+
+        if (winnerDeal == null) {
+            throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
+        }
+
+        if (!winnerDeal.getWinnerId().equals(memberId)) {
+            throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_ACCESS_DENIED);
+        }
+
+        // 구매확정은 구매자 본인의 배송완료 거래에 대해서만 1회 허용한다.
+        if (!"PAID".equals(winnerDeal.getStatus())
+                || !"DELIVERED".equals(winnerDeal.getDeliveryStatus())
+                || winnerDeal.getConfirmedAt() != null) {
+            throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_NOT_ALLOWED);
+        }
+
+        int updatedRows = winnerDealMapper.confirmPurchase(winnerDealId, LocalDateTime.now());
+        if (updatedRows != 1) {
+            throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_FAILED);
+        }
+
+        Long lastBidAmount = bidService.getLastBidAmount(memberId, winnerDeal.getAuctionId());
+        if (lastBidAmount == null || lastBidAmount < winnerDeal.getWinnerPrice()) {
+            throw new CustomException(ErrorType.WINNER_DEAL_SETTLEMENT_INVALID);
+        }
+
+        long refundAmount = lastBidAmount - winnerDeal.getWinnerPrice();
+        if (refundAmount < 0) {
+            throw new CustomException(ErrorType.WINNER_DEAL_SETTLEMENT_INVALID);
+        } else if (refundAmount > 0) {
+            pointService.refundBid(memberId, refundAmount);
         }
     }
 

--- a/src/main/resources/db/migration/V16__add_settlement_to_point_history_type.sql
+++ b/src/main/resources/db/migration/V16__add_settlement_to_point_history_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE point_history
+    MODIFY type VARCHAR(20),
+    ADD CONSTRAINT chk_point_type CHECK (`type` IN ('CHARGE', 'BID', 'EXCHANGE', 'REFUND', 'SETTLEMENT'));

--- a/src/main/resources/db/migration/V16__add_settlement_to_point_history_type.sql
+++ b/src/main/resources/db/migration/V16__add_settlement_to_point_history_type.sql
@@ -1,3 +1,5 @@
 ALTER TABLE point_history
-    MODIFY type VARCHAR(20),
+    DROP CONSTRAINT chk_point_type;
+
+ALTER TABLE point_history
     ADD CONSTRAINT chk_point_type CHECK (`type` IN ('CHARGE', 'BID', 'EXCHANGE', 'REFUND', 'SETTLEMENT'));

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -244,4 +244,11 @@
         WHERE id = #{winnerDealId}
     </update>
 
+    <update id="confirmPurchase">
+        UPDATE winner_deal
+        SET status = 'CONFIRMED',
+            confirmed_at = #{confirmedAt}
+        WHERE id = #{winnerDealId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -244,6 +244,7 @@
         WHERE id = #{winnerDealId}
     </update>
 
+    <!-- 구매자 구매확정 -->
     <update id="confirmPurchase">
         UPDATE winner_deal
         SET status = 'CONFIRMED',


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 구매자가 낙찰 거래를 구매확정할 수 있는 API를 추가했습니다.
- 로그인 사용자가 해당 낙찰 거래의 구매자인지 검증하도록 처리했습니다.
- 구매확정은 배송완료된 본인 거래에 대해서만 가능하도록 상태 검증 로직을 추가했습니다.
- 구매확정 시 winner_deal의 상태를 CONFIRMED로 변경하고 confirmed_at을 저장하도록 구현했습니다.
- 비크리 경매 정산을 위해 낙찰자의 마지막 입찰 금액과 실제 낙찰 금액의 차액을 환불 처리하도록 반영했습니다.
- 구매확정 불가, 권한 없음, 정산 불일치, 처리 실패에 대한 예외 처리를 추가했습니다.

---

## 📎 관련 이슈
- #193