### PR TITLE
feat: 회원 프로필 조회 응답에 리뷰 정보, 등급, 가입일 추가

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberProfileResponse.java
@@ -21,4 +21,9 @@ public class MemberProfileResponse {
     private String bankCode;
     private String bankAccount;
 
+    private LocalDateTime createdAt;
+    private long reviewCount;
+    private Double ratingAvg;
+
+    private String grade;
 }

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -118,16 +118,32 @@
             m.name AS name,
             m.nickname AS nickname,
             m.email AS email,
-
+            m.grade AS grade,
             a.zipcode AS zipcode,
             a.address AS address,
             a.detail_address AS detailAddress,
 
             m.bank_code AS bankCode,
-            m.bank_account AS bankAccount
+            m.bank_account AS bankAccount,
+
+            m.created_at AS createdAt,
+
+            COALESCE(r.reviewCount, 0) AS reviewCount,
+            COALESCE(r.ratingAvg, 0) AS ratingAvg
 
         FROM member m
                  LEFT JOIN address a ON m.id = a.member_id
+            AND a.default_yn = 1
+
+                 LEFT JOIN (
+            SELECT
+                target_id,
+                COUNT(*) AS reviewCount,
+                AVG(rating) AS ratingAvg
+            FROM review
+            GROUP BY target_id
+        ) r ON m.id = r.target_id
+
         WHERE m.id = #{memberId}
     </select>
 


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 기존 프로필 정보에 아래 항목 추가
  - 리뷰 총 개수 (`reviewCount`)
  - 리뷰 평균 평점 (`ratingAvg`)
  - 회원 가입일 (`createdAt`)
  - 회원 등급 (`grade`)
- `COALESCE`를 사용하여 리뷰가 없는 경우 기본값(0) 반환 처리
- 주소 조회 시 기본 주소(`default_yn = 1`)만 조회하도록 쿼리 수정
- `MemberProfileResponse` DTO에 신규 필드 추가 및 매핑 처리

---

## 📎 관련 이슈

- close #199
