### PR TITLE
feat: 관리자 거래 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/AdminWinnerDealController.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/AdminWinnerDealController.java
@@ -1,0 +1,34 @@
+package com.biddingmate.biddinggo.winnerdeal.controller;
+
+import com.biddingmate.biddinggo.common.response.ApiResponse;
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
+import com.biddingmate.biddinggo.winnerdeal.service.WinnerDealQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admins/winner-deals")
+@Tag(name = "Admin-Winner-Deal", description = "관리자 거래 관리 API")
+public class AdminWinnerDealController {
+    private final WinnerDealQueryService winnerDealQueryService;
+
+    @GetMapping("")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "관리자 거래 내역 조회", description = "관리자가 거래 번호와 상태 조건으로 거래 내역을 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<AdminWinnerDealListResponse>>> findAdminWinnerDealHistory(@Valid AdminWinnerDealListRequest request) {
+        PageResponse<AdminWinnerDealListResponse> result = winnerDealQueryService.findAdminWinnerDealHistory(request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "관리자 거래 내역 조회에 성공했습니다.", result);
+    }
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListRequest.java
@@ -1,0 +1,24 @@
+package com.biddingmate.biddinggo.winnerdeal.dto;
+
+import com.biddingmate.biddinggo.common.request.BasePageRequest;
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Schema(description = "관리자 거래 내역 조회 요청")
+public class AdminWinnerDealListRequest extends BasePageRequest {
+    @Schema(description = "거래 상태", example = "CONFIRMED", nullable = true)
+    private WinnerDealStatus status;
+
+    @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3", nullable = true)
+    private Long dealNumber;
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListRequest.java
@@ -20,5 +20,5 @@ public class AdminWinnerDealListRequest extends BasePageRequest {
     private WinnerDealStatus status;
 
     @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3", nullable = true)
-    private Long dealNumber;
+    private String dealNumber;
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @Schema(description = "관리자 거래 내역 조회 응답")
 public class AdminWinnerDealListResponse {
     @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3")
-    private Long dealNumber;
+    private String dealNumber;
 
     @Schema(description = "판매자 닉네임", example = "김셀러")
     private String sellerName;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
@@ -1,0 +1,36 @@
+package com.biddingmate.biddinggo.winnerdeal.dto;
+
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "관리자 거래 내역 조회 응답")
+public class AdminWinnerDealListResponse {
+    @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3")
+    private Long dealNumber;
+
+    @Schema(description = "판매자 닉네임", example = "김셀러")
+    private String sellerName;
+
+    @Schema(description = "구매자 닉네임", example = "김구매")
+    private String winnerName;
+
+    @Schema(description = "상품명", example = "맥북 프로 M3 14인치")
+    private String itemName;
+
+    @Schema(description = "거래 금액", example = "2280000")
+    private Long winnerPrice;
+
+    @Schema(description = "거래일", example = "2026-02-01T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "거래 상태", example = "SHIPPED")
+    private WinnerDealStatus status;
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
@@ -13,6 +13,9 @@ import java.time.LocalDateTime;
 @Builder
 @Schema(description = "관리자 거래 내역 조회 응답")
 public class AdminWinnerDealListResponse {
+    @Schema(description = "낙찰 거래 ID", example = "101")
+    private Long winnerDealId;
+
     @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3")
     private String dealNumber;
 

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailQueryResult.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailQueryResult.java
@@ -16,7 +16,6 @@ public class WinnerDealDetailQueryResult {
     private String itemImageUrl;
     private Long winnerPrice;
     private String status;
-    private String deliveryStatus;
     private String sellerName;
     private String winnerName;
     private String recipient;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailQueryResult.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailQueryResult.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.winnerdeal.dto;
 
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -15,7 +16,7 @@ public class WinnerDealDetailQueryResult {
     private String itemName;
     private String itemImageUrl;
     private Long winnerPrice;
-    private String status;
+    private WinnerDealStatus status;
     private String sellerName;
     private String winnerName;
     private String recipient;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailQueryResult.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailQueryResult.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 @Getter
 public class WinnerDealDetailQueryResult {
     private Long winnerDealId;
+    private String dealNumber;
     private Long auctionId;
     private Long itemId;
     private Long winnerId;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealDetailResponse.java
@@ -16,6 +16,9 @@ public class WinnerDealDetailResponse {
     @Schema(description = "낙찰 거래 ID", example = "101")
     private Long winnerDealId;
 
+    @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3")
+    private String dealNumber;
+
     @Schema(description = "경매 ID", example = "201")
     private Long auctionId;
 

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealHistoryResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/WinnerDealHistoryResponse.java
@@ -15,6 +15,9 @@ public class WinnerDealHistoryResponse {
     @Schema(description = "낙찰 거래 ID", example = "101")
     private Long winnerDealId;
 
+    @Schema(description = "거래 번호", example = "WD_20260409_A1B2C3")
+    private String dealNumber;
+
     @Schema(description = "경매 ID", example = "201")
     private Long auctionId;
 

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -19,6 +19,7 @@ public interface WinnerDealMapper {
     int insert(WinnerDeal winnerDeal);
     WinnerDeal findById(Long id);
     WinnerDeal findByAuctionId(Long auctionId);
+    boolean existsByDealNumber(@Param("dealNumber") String dealNumber);
 
     List<WinnerDeal> findByMemberId(@Param("memberId") Long memberId);
 

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -1,5 +1,7 @@
 package com.biddingmate.biddinggo.winnerdeal.mapper;
 
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
@@ -36,6 +38,10 @@ public interface WinnerDealMapper {
                                                     @Param("memberId") Long memberId);
     long countSaleHistory(@Param("request") WinnerDealHistoryRequest request,
                           @Param("memberId") Long memberId);
+    List<AdminWinnerDealListResponse> findAdminWinnerDealHistory(RowBounds rowBounds,
+                                                                 @Param("request") AdminWinnerDealListRequest request,
+                                                                 @Param("order") String order);
+    long countAdminWinnerDealHistory(@Param("request") AdminWinnerDealListRequest request);
 
     // 거래 내역 상세 조회
     WinnerDealDetailQueryResult findWinnerDealDetail(@Param("winnerDealId") Long winnerDealId);

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDeal.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDeal.java
@@ -13,6 +13,7 @@ public class WinnerDeal {
     private Long auctionId;
     private Long winnerId;
     private Long sellerId;
+    private String dealNumber;
     private Long winnerPrice;
     private String status;          // 기본값 'PAID'
     private String deliveryStatus;  // 추가: 기본값 'SHIPPED'

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDeal.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDeal.java
@@ -1,6 +1,11 @@
 package com.biddingmate.biddinggo.winnerdeal.model;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDateTime;
 
 @Getter
@@ -15,8 +20,7 @@ public class WinnerDeal {
     private Long sellerId;
     private String dealNumber;
     private Long winnerPrice;
-    private String status;          // 기본값 'PAID'
-    private String deliveryStatus;  // 추가: 기본값 'SHIPPED'
+    private String status;
     private LocalDateTime confirmedAt;
     private String zipcode;
     private String address;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDeal.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDeal.java
@@ -20,7 +20,7 @@ public class WinnerDeal {
     private Long sellerId;
     private String dealNumber;
     private Long winnerPrice;
-    private String status;
+    private WinnerDealStatus status;
     private LocalDateTime confirmedAt;
     private String zipcode;
     private String address;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDealStatus.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/model/WinnerDealStatus.java
@@ -2,8 +2,7 @@ package com.biddingmate.biddinggo.winnerdeal.model;
 
 public enum WinnerDealStatus {
     PAID,                // 발송 대기
-    SHIPPED,            // 배송 중
-    DELIVERED,           //  배송 완료
+    SHIPPED,             // 배송 중
     CONFIRMED,           // 거래 완료
-    CANCELLED;           // 취소
+    CANCELLED            // 취소
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryService.java
@@ -1,6 +1,8 @@
 package com.biddingmate.biddinggo.winnerdeal.service;
 
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryResponse;
@@ -21,4 +23,7 @@ public interface WinnerDealQueryService {
 
     // 거래 내역 상세조회
     WinnerDealDetailResponse findWinnerDealDetail(Long winnerDealId, Long memberId);
+
+    // 관리자 거래 내역 조회
+    PageResponse<AdminWinnerDealListResponse> findAdminWinnerDealHistory(@Valid AdminWinnerDealListRequest request);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -90,6 +90,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
 
         return WinnerDealDetailResponse.builder()
                 .winnerDealId(detail.getWinnerDealId())
+                .dealNumber(detail.getDealNumber())
                 .auctionId(detail.getAuctionId())
                 .itemId(detail.getItemId())
                 .viewerRole(isBuyer ? "BUYER" : "SELLER")

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -77,7 +77,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
             throw new CustomException(ErrorType.WINNER_DEAL_ACCESS_DENIED);
         }
 
-        WinnerDealStatus status = WinnerDealStatus.valueOf(detail.getStatus());
+        WinnerDealStatus status = detail.getStatus();
         // 배송지 등록 여부
         boolean shippingAddressRegistered = isShippingAddressRegistered(detail);
         // 운송장 등록 여부

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -4,6 +4,8 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.review.mapper.ReviewMapper;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
@@ -111,6 +113,25 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
                 .confirmedAt(detail.getConfirmedAt())
                 .createdAt(detail.getCreatedAt())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AdminWinnerDealListResponse> findAdminWinnerDealHistory(AdminWinnerDealListRequest request) {
+        String order = request.getOrder();
+        if (!"ASC".equalsIgnoreCase(order) && !"DESC".equalsIgnoreCase(order)) {
+            throw new CustomException(ErrorType.INVALID_SORT_ORDER);
+        }
+
+        RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
+        String sortOrder = order.toUpperCase();
+
+        List<AdminWinnerDealListResponse> content =
+                winnerDealMapper.findAdminWinnerDealHistory(rowBounds, request, sortOrder);
+
+        long totalElements = winnerDealMapper.countAdminWinnerDealHistory(request);
+
+        return PageResponse.of(content, request.getPage(), request.getSize(), totalElements);
     }
 
     private WinnerDealStatus resolveStatus(WinnerDealDetailQueryResult detail) {

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -77,14 +77,11 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
             throw new CustomException(ErrorType.WINNER_DEAL_ACCESS_DENIED);
         }
 
-        WinnerDealStatus status = resolveStatus(detail);
-
+        WinnerDealStatus status = WinnerDealStatus.valueOf(detail.getStatus());
         // 배송지 등록 여부
         boolean shippingAddressRegistered = isShippingAddressRegistered(detail);
-
         // 운송장 등록 여부
         boolean trackingNumberRegistered = isTrackingNumberRegistered(detail);
-
         // 구매자가 해당 낙찰 거래에 리뷰를 이미 작성했는지 확인
         boolean reviewWritten = reviewMapper.countByDealIdAndWriterId(detail.getWinnerDealId(), memberId) > 0;
 
@@ -109,7 +106,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
                 .trackingNumber(detail.getTrackingNumber())
                 .canRegisterShippingAddress(isBuyer && !shippingAddressRegistered && status == WinnerDealStatus.PAID)
                 .canRegisterTrackingNumber(isSeller && shippingAddressRegistered && !trackingNumberRegistered && status == WinnerDealStatus.PAID)
-                .canConfirmPurchase(isBuyer && status == WinnerDealStatus.DELIVERED && detail.getConfirmedAt() == null)
+                .canConfirmPurchase(isBuyer && status == WinnerDealStatus.SHIPPED && detail.getConfirmedAt() == null)
                 .canWriteReview(isBuyer && status == WinnerDealStatus.CONFIRMED && !reviewWritten)
                 .confirmedAt(detail.getConfirmedAt())
                 .createdAt(detail.getCreatedAt())
@@ -133,22 +130,6 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
         long totalElements = winnerDealMapper.countAdminWinnerDealHistory(request);
 
         return PageResponse.of(content, request.getPage(), request.getSize(), totalElements);
-    }
-
-    private WinnerDealStatus resolveStatus(WinnerDealDetailQueryResult detail) {
-        if ("CANCELLED".equals(detail.getStatus())) {
-            return WinnerDealStatus.CANCELLED;
-        }
-        if ("CONFIRMED".equals(detail.getStatus())) {
-            return WinnerDealStatus.CONFIRMED;
-        }
-        if ("DELIVERED".equals(detail.getDeliveryStatus())) {
-            return WinnerDealStatus.DELIVERED;
-        }
-        if (StringUtils.hasText(detail.getTrackingNumber())) {
-            return WinnerDealStatus.SHIPPED;
-        }
-        return WinnerDealStatus.PAID;
     }
 
     private boolean isShippingAddressRegistered(WinnerDealDetailQueryResult detail) {

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -29,12 +29,16 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class WinnerDealServiceImpl implements WinnerDealService {
+    private static final DateTimeFormatter DEAL_NUMBER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
     private final AuctionMapper auctionMapper;
     private final BidMapper bidMapper;
     private final BidService bidService;
@@ -69,6 +73,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
                     .auctionId(auction.getId())
                     .winnerId(winnerBid.getBidderId())
                     .sellerId(auction.getSellerId())
+                    .dealNumber(generateDealNumber())
                     .winnerPrice(finalPrice)
                     .status("PAID")
                     .deliveryStatus("SHIPPED")
@@ -284,5 +289,10 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
         return StringUtils.hasText(winnerDeal.getCarrier())
                 && StringUtils.hasText(winnerDeal.getTrackingNumber());
+    }
+    private String generateDealNumber() {
+        String datePart = LocalDateTime.now().format(DEAL_NUMBER_DATE_FORMATTER);
+        String randomPart = UUID.randomUUID().toString().replace("-", "").substring(0, 6).toUpperCase();
+        return "WD-" + datePart + "-" + randomPart;
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -19,6 +19,7 @@ import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDeal;
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.session.RowBounds;
@@ -74,7 +75,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
                     .sellerId(auction.getSellerId())
                     .dealNumber(generateDealNumber())
                     .winnerPrice(finalPrice)
-                    .status("PAID")
+                    .status(WinnerDealStatus.PAID)
                     .createdAt(LocalDateTime.now())
                     .build();
 
@@ -162,7 +163,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         }
 
         // 배송지 또는 운송장 정보가 이미 있거나 PAID 상태가 아닌 경우
-        if (!"PAID".equals(winnerDeal.getStatus())
+        if (winnerDeal.getStatus() != WinnerDealStatus.PAID
                 || isShippingInfoRegistered(winnerDeal)
                 || isTrackingNumberRegistered(winnerDeal)) {
             throw new CustomException(ErrorType.WINNER_DEAL_SHIPPING_ADDRESS_REGISTRATION_NOT_ALLOWED);
@@ -189,7 +190,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         }
 
         // 운송장 등록은 PAID 상태에서 배송지 정보가 있고 아직 운송장 정보가 없을 때만 허용한다.
-        if (!"PAID".equals(winnerDeal.getStatus())
+        if (winnerDeal.getStatus() != WinnerDealStatus.PAID
                 || !isShippingInfoRegistered(winnerDeal)
                 || isTrackingNumberRegistered(winnerDeal)) {
             throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED);
@@ -215,7 +216,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         }
 
         // 구매확정은 구매자 본인의 배송 중 거래에 대해서만 1회 허용한다.
-        if (!"SHIPPED".equals(winnerDeal.getStatus())
+        if (winnerDeal.getStatus() != WinnerDealStatus.SHIPPED
                 || winnerDeal.getConfirmedAt() != null) {
             throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_NOT_ALLOWED);
         }
@@ -241,7 +242,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
     }
 
     private void refundAndCancelWinnerDeal(WinnerDeal winnerDeal) {
-        if ("CANCELLED".equals(winnerDeal.getStatus())) {
+        if (winnerDeal.getStatus() == WinnerDealStatus.CANCELLED) {
             throw new CustomException(ErrorType.WINNER_DEAL_ALREADY_CANCELLED);
         }
 

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -7,7 +7,6 @@ import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.auction.prediction.event.AuctionPriceReferenceSyncRequestedEvent;
 import com.biddingmate.biddinggo.bid.dto.BidResponse;
 import com.biddingmate.biddinggo.bid.mapper.BidMapper;
-import com.biddingmate.biddinggo.bid.model.Bid;
 import com.biddingmate.biddinggo.bid.service.BidQueryService;
 import com.biddingmate.biddinggo.bid.service.BidService;
 import com.biddingmate.biddinggo.common.exception.CustomException;
@@ -76,7 +75,6 @@ public class WinnerDealServiceImpl implements WinnerDealService {
                     .dealNumber(generateDealNumber())
                     .winnerPrice(finalPrice)
                     .status("PAID")
-                    .deliveryStatus("SHIPPED")
                     .createdAt(LocalDateTime.now())
                     .build();
 
@@ -130,25 +128,23 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         }
     }
 
-
     @Override
     @Transactional
     public void handleMemberDeactivationAfterWinning(Long memberId) {
-        log.info("낙찰 후 회원 비활성화 처리 시작 - Member ID: {}", memberId);
+        log.info("낙찰 회원 비활성화 처리 시작 - Member ID: {}", memberId);
 
         List<WinnerDeal> winnerDeals = winnerDealQueryService.findByMemberId(memberId);
 
         for (WinnerDeal winnerDeal : winnerDeals) {
             if (isShippingInfoRegistered(winnerDeal)) {
-                log.info("낙찰 후 비활성화 거래 유지 - WinnerDeal ID: {}, Auction ID: {}",
+                log.info("낙찰 회원 비활성화 거래 유지 - WinnerDeal ID: {}, Auction ID: {}",
                         winnerDeal.getId(), winnerDeal.getAuctionId());
                 return;
             }
-            // 비활성화 시 낙찰 취소 및 낙찰자의 예치금 환불
             refundAndCancelWinnerDeal(winnerDeal);
         }
 
-        log.info("낙찰 후 비활성화 대상 거래 수 - Member ID: {}, Count: {}", memberId, winnerDeals.size());
+        log.info("낙찰 회원 비활성화 대상 거래 수 - Member ID: {}, Count: {}", memberId, winnerDeals.size());
     }
 
     @Override
@@ -218,9 +214,8 @@ public class WinnerDealServiceImpl implements WinnerDealService {
             throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_ACCESS_DENIED);
         }
 
-        // 구매확정은 구매자 본인의 배송완료 거래에 대해서만 1회 허용한다.
-        if (!"PAID".equals(winnerDeal.getStatus())
-                || !"DELIVERED".equals(winnerDeal.getDeliveryStatus())
+        // 구매확정은 구매자 본인의 배송 중 거래에 대해서만 1회 허용한다.
+        if (!"SHIPPED".equals(winnerDeal.getStatus())
                 || winnerDeal.getConfirmedAt() != null) {
             throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_NOT_ALLOWED);
         }
@@ -290,9 +285,11 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         return StringUtils.hasText(winnerDeal.getCarrier())
                 && StringUtils.hasText(winnerDeal.getTrackingNumber());
     }
+
     private String generateDealNumber() {
         String datePart = LocalDateTime.now().format(DEAL_NUMBER_DATE_FORMATTER);
         String randomPart = UUID.randomUUID().toString().replace("-", "").substring(0, 6).toUpperCase();
         return "WD-" + datePart + "-" + randomPart;
     }
 }
+

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class WinnerDealServiceImpl implements WinnerDealService {
     private static final DateTimeFormatter DEAL_NUMBER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final int DEAL_NUMBER_MAX_RETRY_COUNT = 10;
 
     private final AuctionMapper auctionMapper;
     private final BidMapper bidMapper;
@@ -288,9 +289,17 @@ public class WinnerDealServiceImpl implements WinnerDealService {
     }
 
     private String generateDealNumber() {
-        String datePart = LocalDateTime.now().format(DEAL_NUMBER_DATE_FORMATTER);
-        String randomPart = UUID.randomUUID().toString().replace("-", "").substring(0, 6).toUpperCase();
-        return "WD-" + datePart + "-" + randomPart;
+        for (int attempt = 0; attempt < DEAL_NUMBER_MAX_RETRY_COUNT; attempt++) {
+            String datePart = LocalDateTime.now().format(DEAL_NUMBER_DATE_FORMATTER);
+            String randomPart = UUID.randomUUID().toString().replace("-", "").substring(0, 6).toUpperCase();
+            String dealNumber = "WD-" + datePart + "-" + randomPart;
+
+            if (!winnerDealMapper.existsByDealNumber(dealNumber)) {
+                return dealNumber;
+            }
+        }
+
+        throw new CustomException(ErrorType.WINNER_DEAL_UPDATE_FAILED);
     }
 }
 

--- a/src/main/resources/db/migration/V17__add_deal_number_to_winner_deal.sql
+++ b/src/main/resources/db/migration/V17__add_deal_number_to_winner_deal.sql
@@ -1,0 +1,10 @@
+ALTER TABLE winner_deal
+    ADD COLUMN deal_number VARCHAR(50) NULL AFTER seller_id;
+
+UPDATE winner_deal
+SET deal_number = CONCAT('WD-', DATE_FORMAT(created_at, '%Y%m%d'), '-', LPAD(id, 6, '0'))
+WHERE deal_number IS NULL;
+
+ALTER TABLE winner_deal
+    MODIFY COLUMN deal_number VARCHAR(50) NOT NULL,
+    ADD CONSTRAINT uk_winner_deal_deal_number UNIQUE (deal_number);

--- a/src/main/resources/db/migration/V18__merge_winner_deal_status.sql
+++ b/src/main/resources/db/migration/V18__merge_winner_deal_status.sql
@@ -1,0 +1,11 @@
+ALTER TABLE winner_deal
+    MODIFY COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PAID'
+    CHECK (`status` IN ('PAID', 'SHIPPED', 'CONFIRMED', 'CANCELLED'));
+
+UPDATE winner_deal
+SET status = 'SHIPPED'
+WHERE status = 'PAID'
+  AND (delivery_status = 'DELIVERED' OR tracking_number IS NOT NULL);
+
+ALTER TABLE winner_deal
+    DROP COLUMN delivery_status;

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -1,74 +1,67 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper">
-    <insert id="insert" parameterType="WinnerDeal"
-            useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO winner_deal (
-            auction_id,
-            winner_id,
-            seller_id,
-            deal_number,
-            winner_price,
-            status,
-            delivery_status,
-            created_at
-        ) VALUES (
-                     #{auctionId},
-                     #{winnerId},
-                     #{sellerId},
-                     #{dealNumber},
-                     #{winnerPrice},
-                     #{status},
-                     #{deliveryStatus},
-                     #{createdAt}
-                 )
+    <insert id="insert" parameterType="WinnerDeal" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO winner_deal (auction_id,
+                                 winner_id,
+                                 seller_id,
+                                 deal_number,
+                                 winner_price,
+                                 status,
+                                 created_at
+        ) VALUES (#{auctionId},
+                  #{winnerId},
+                  #{sellerId},
+                  #{dealNumber},
+                  #{winnerPrice},
+                  #{status},
+                  #{createdAt}
+        )
     </insert>
+
     <select id="findById" resultType="WinnerDeal">
-        SELECT
-            id,
-            auction_id AS auctionId,
-            winner_id AS winnerId,
-            seller_id AS sellerId,
-            deal_number AS dealNumber,
-            winner_price AS winnerPrice,
-            status,
-            delivery_status AS deliveryStatus,
-            confirmed_at AS confirmedAt,
-            zipcode,
-            address,
-            detail_address AS detailAddress,
-            tel,
-            recipient,
-            carrier,
-            tracking_number AS trackingNumber,
-            created_at AS createdAt
+        SELECT id,
+               auction_id AS auctionId,
+               winner_id AS winnerId,
+               seller_id AS sellerId,
+               deal_number AS dealNumber,
+               winner_price AS winnerPrice,
+               status,
+               confirmed_at AS confirmedAt,
+               zipcode,
+               address,
+               detail_address AS detailAddress,
+               tel,
+               recipient,
+               carrier,
+               tracking_number AS trackingNumber,
+               created_at AS createdAt
         FROM winner_deal
         WHERE id = #{id}
         LIMIT 1
     </select>
+
     <select id="findByAuctionId" resultType="WinnerDeal">
-        SELECT
-            id,
-            auction_id AS auctionId,
-            winner_id AS winnerId,
-            seller_id AS sellerId,
-            deal_number AS dealNumber,
-            winner_price AS winnerPrice,
-            status,
-            delivery_status AS deliveryStatus,
-            confirmed_at AS confirmedAt,
-            zipcode,
-            address,
-            detail_address AS detailAddress,
-            tel,
-            recipient,
-            carrier,
-            tracking_number AS trackingNumber,
-            created_at AS createdAt
+        SELECT id,
+               auction_id AS auctionId,
+               winner_id AS winnerId,
+               seller_id AS sellerId,
+               deal_number AS dealNumber,
+               winner_price AS winnerPrice,
+               status,
+               confirmed_at AS confirmedAt,
+               zipcode,
+               address,
+               detail_address AS detailAddress,
+               tel,
+               recipient,
+               carrier,
+               tracking_number AS trackingNumber,
+               created_at AS createdAt
         FROM winner_deal
         WHERE auction_id = #{auctionId}
-            LIMIT 1
+        LIMIT 1
     </select>
 
     <select id="findByMemberId" resultType="WinnerDeal">
@@ -79,7 +72,6 @@
                deal_number AS dealNumber,
                winner_price AS winnerPrice,
                status,
-               delivery_status AS deliveryStatus,
                confirmed_at AS confirmedAt,
                zipcode,
                address,
@@ -106,17 +98,9 @@
             <choose>
                 <when test="request.status.name() == 'PAID'">
                     AND wd.status = 'PAID'
-                    AND wd.delivery_status = 'SHIPPED'
-                    AND wd.tracking_number IS NULL
                 </when>
                 <when test="request.status.name() == 'SHIPPED'">
-                    AND wd.status = 'PAID'
-                    AND wd.delivery_status = 'SHIPPED'
-                    AND wd.tracking_number IS NOT NULL
-                </when>
-                <when test="request.status.name() == 'DELIVERED'">
-                    AND wd.status = 'PAID'
-                    AND wd.delivery_status = 'DELIVERED'
+                    AND wd.status = 'SHIPPED'
                 </when>
                 <when test="request.status.name() == 'CONFIRMED'">
                     AND wd.status = 'CONFIRMED'
@@ -136,13 +120,7 @@
                ai.id AS itemId,
                ai.name AS itemName,
                ii.url AS imageUrl,
-               CASE
-                   WHEN wd.status = 'CANCELLED' THEN 'CANCELLED'
-                   WHEN wd.status = 'CONFIRMED' THEN 'CONFIRMED'
-                   WHEN wd.delivery_status = 'DELIVERED' THEN 'DELIVERED'
-                   WHEN wd.tracking_number IS NOT NULL THEN 'SHIPPED'
-                   ELSE 'PAID'
-               END AS status,
+               wd.status AS status,
                wd.winner_price AS winnerPrice,
                wd.confirmed_at AS confirmedAt,
                wd.created_at AS createdAt
@@ -152,7 +130,7 @@
         LEFT JOIN item_image ii ON ii.item_id = ai.id AND ii.display_order = 1
         WHERE wd.winner_id = #{memberId}
         <include refid="winnerDealHistoryStatusFilter"/>
-        ORDER BY wd.created_at DESC
+        ORDER BY wd.created_at DESC, wd.id DESC
     </select>
 
     <select id="countPurchaseHistory" resultType="long">
@@ -172,13 +150,7 @@
                ai.id AS itemId,
                ai.name AS itemName,
                ii.url AS imageUrl,
-               CASE
-                   WHEN wd.status = 'CANCELLED' THEN 'CANCELLED'
-                   WHEN wd.status = 'CONFIRMED' THEN 'CONFIRMED'
-                   WHEN wd.delivery_status = 'DELIVERED' THEN 'DELIVERED'
-                   WHEN wd.tracking_number IS NOT NULL THEN 'SHIPPED'
-                   ELSE 'PAID'
-               END AS status,
+               wd.status AS status,
                wd.winner_price AS winnerPrice,
                wd.confirmed_at AS confirmedAt,
                wd.created_at AS createdAt
@@ -188,7 +160,7 @@
         LEFT JOIN item_image ii ON ii.item_id = ai.id AND ii.display_order = 1
         WHERE wd.seller_id = #{memberId}
         <include refid="winnerDealHistoryStatusFilter"/>
-        ORDER BY wd.created_at DESC
+        ORDER BY wd.created_at DESC, wd.id DESC
     </select>
 
     <select id="countSaleHistory" resultType="long">
@@ -208,17 +180,9 @@
             <choose>
                 <when test="request.status.name() == 'PAID'">
                     AND wd.status = 'PAID'
-                    AND wd.delivery_status = 'SHIPPED'
-                    AND wd.tracking_number IS NULL
                 </when>
                 <when test="request.status.name() == 'SHIPPED'">
-                    AND wd.status = 'PAID'
-                    AND wd.delivery_status = 'SHIPPED'
-                    AND wd.tracking_number IS NOT NULL
-                </when>
-                <when test="request.status.name() == 'DELIVERED'">
-                    AND wd.status = 'PAID'
-                    AND wd.delivery_status = 'DELIVERED'
+                    AND wd.status = 'SHIPPED'
                 </when>
                 <when test="request.status.name() == 'CONFIRMED'">
                     AND wd.status = 'CONFIRMED'
@@ -229,41 +193,6 @@
             </choose>
         </if>
     </sql>
-
-    <select id="findAdminWinnerDealHistory" resultType="AdminWinnerDealListResponse">
-        SELECT wd.deal_number AS dealNumber,
-               seller.nickname AS sellerName,
-               winner.nickname AS winnerName,
-               ai.name AS itemName,
-               wd.winner_price AS winnerPrice,
-               wd.created_at AS createdAt,
-               CASE
-                   WHEN wd.status = 'CANCELLED' THEN 'CANCELLED'
-                   WHEN wd.status = 'CONFIRMED' THEN 'CONFIRMED'
-                   WHEN wd.delivery_status = 'DELIVERED' THEN 'DELIVERED'
-                   WHEN wd.tracking_number IS NOT NULL THEN 'SHIPPED'
-                   ELSE 'PAID'
-               END AS status
-        FROM winner_deal wd
-        JOIN auction a ON wd.auction_id = a.id
-        JOIN auction_item ai ON a.item_id = ai.id
-        JOIN member seller ON seller.id = wd.seller_id
-        JOIN member winner ON winner.id = wd.winner_id
-        WHERE 1 = 1
-        <include refid="adminWinnerDealHistoryFilter"/>
-        ORDER BY wd.created_at ${order}
-    </select>
-
-    <select id="countAdminWinnerDealHistory" resultType="long">
-        SELECT COUNT(*)
-        FROM winner_deal wd
-        JOIN auction a ON wd.auction_id = a.id
-        JOIN auction_item ai ON a.item_id = ai.id
-        JOIN member seller ON seller.id = wd.seller_id
-        JOIN member winner ON winner.id = wd.winner_id
-        WHERE 1 = 1
-        <include refid="adminWinnerDealHistoryFilter"/>
-    </select>
 
     <select id="findWinnerDealDetail" resultType="WinnerDealDetailQueryResult">
         SELECT wd.id AS winnerDealId,
@@ -276,7 +205,6 @@
                ii.url AS itemImageUrl,
                wd.winner_price AS winnerPrice,
                wd.status AS status,
-               wd.delivery_status AS deliveryStatus,
                seller.nickname AS sellerName,
                winner.nickname AS winnerName,
                wd.recipient AS recipient,
@@ -313,7 +241,8 @@
     <update id="updateTrackingNumber">
         UPDATE winner_deal
         SET carrier = #{request.carrier},
-            tracking_number = #{request.trackingNumber}
+            tracking_number = #{request.trackingNumber},
+            status = 'SHIPPED'
         WHERE id = #{winnerDealId}
     </update>
 
@@ -324,5 +253,34 @@
             confirmed_at = #{confirmedAt}
         WHERE id = #{winnerDealId}
     </update>
+
+    <!-- 관리자 구매내역 조회 -->
+    <select id="findAdminWinnerDealHistory" resultType="AdminWinnerDealListResponse">
+        SELECT wd.id AS winnerDealId,
+               wd.deal_number AS dealNumber,
+               seller.nickname AS sellerName,
+               winner.nickname AS winnerName,
+               ai.name AS itemName,
+               wd.winner_price AS winnerPrice,
+               wd.created_at AS createdAt,
+               wd.status AS status
+        FROM winner_deal wd
+        JOIN auction a ON wd.auction_id = a.id
+        JOIN auction_item ai ON a.item_id = ai.id
+        JOIN member seller ON seller.id = wd.seller_id
+        JOIN member winner ON winner.id = wd.winner_id
+        <include refid="adminWinnerDealHistoryFilter"/>
+        ORDER BY wd.created_at ${order}, wd.id DESC
+    </select>
+
+    <select id="countAdminWinnerDealHistory" resultType="long">
+        SELECT COUNT(*)
+        FROM winner_deal wd
+        JOIN auction a ON wd.auction_id = a.id
+        JOIN auction_item ai ON a.item_id = ai.id
+        JOIN member seller ON seller.id = wd.seller_id
+        JOIN member winner ON winner.id = wd.winner_id
+        <include refid="adminWinnerDealHistoryFilter"/>
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -112,6 +112,29 @@
         </if>
     </sql>
 
+    <!-- 관리자 거래 내역 조회 시 필터링 조각 -->
+    <sql id="adminWinnerDealHistoryFilter">
+        <if test="request.dealNumber != null and request.dealNumber != ''">
+            AND wd.deal_number = #{request.dealNumber}
+        </if>
+        <if test="request.status != null">
+            <choose>
+                <when test="request.status.name() == 'PAID'">
+                    AND wd.status = 'PAID'
+                </when>
+                <when test="request.status.name() == 'SHIPPED'">
+                    AND wd.status = 'SHIPPED'
+                </when>
+                <when test="request.status.name() == 'CONFIRMED'">
+                    AND wd.status = 'CONFIRMED'
+                </when>
+                <when test="request.status.name() == 'CANCELLED'">
+                    AND wd.status = 'CANCELLED'
+                </when>
+            </choose>
+        </if>
+    </sql>
+
     <!-- 구매내역 조회 -->
     <select id="findPurchaseHistory" resultType="WinnerDealHistoryResponse">
         SELECT wd.id AS winnerDealId,
@@ -171,28 +194,6 @@
         WHERE wd.seller_id = #{memberId}
         <include refid="winnerDealHistoryStatusFilter"/>
     </select>
-
-    <sql id="adminWinnerDealHistoryFilter">
-        <if test="request.dealNumber != null and request.dealNumber != ''">
-            AND wd.deal_number = #{request.dealNumber}
-        </if>
-        <if test="request.status != null">
-            <choose>
-                <when test="request.status.name() == 'PAID'">
-                    AND wd.status = 'PAID'
-                </when>
-                <when test="request.status.name() == 'SHIPPED'">
-                    AND wd.status = 'SHIPPED'
-                </when>
-                <when test="request.status.name() == 'CONFIRMED'">
-                    AND wd.status = 'CONFIRMED'
-                </when>
-                <when test="request.status.name() == 'CANCELLED'">
-                    AND wd.status = 'CANCELLED'
-                </when>
-            </choose>
-        </if>
-    </sql>
 
     <select id="findWinnerDealDetail" resultType="WinnerDealDetailQueryResult">
         SELECT wd.id AS winnerDealId,

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -270,7 +270,7 @@
         JOIN member seller ON seller.id = wd.seller_id
         JOIN member winner ON winner.id = wd.winner_id
         <include refid="adminWinnerDealHistoryFilter"/>
-        ORDER BY wd.created_at ${order}, wd.id DESC
+        ORDER BY wd.created_at DESC, wd.id DESC
     </select>
 
     <select id="countAdminWinnerDealHistory" resultType="long">

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -8,6 +8,7 @@
             auction_id,
             winner_id,
             seller_id,
+            deal_number,
             winner_price,
             status,
             delivery_status,
@@ -16,6 +17,7 @@
                      #{auctionId},
                      #{winnerId},
                      #{sellerId},
+                     #{dealNumber},
                      #{winnerPrice},
                      #{status},
                      #{deliveryStatus},
@@ -28,6 +30,7 @@
             auction_id AS auctionId,
             winner_id AS winnerId,
             seller_id AS sellerId,
+            deal_number AS dealNumber,
             winner_price AS winnerPrice,
             status,
             delivery_status AS deliveryStatus,
@@ -50,6 +53,7 @@
             auction_id AS auctionId,
             winner_id AS winnerId,
             seller_id AS sellerId,
+            deal_number AS dealNumber,
             winner_price AS winnerPrice,
             status,
             delivery_status AS deliveryStatus,
@@ -72,6 +76,7 @@
                auction_id AS auctionId,
                winner_id AS winnerId,
                seller_id AS sellerId,
+               deal_number AS dealNumber,
                winner_price AS winnerPrice,
                status,
                delivery_status AS deliveryStatus,
@@ -126,6 +131,7 @@
     <!-- 구매내역 조회 -->
     <select id="findPurchaseHistory" resultType="WinnerDealHistoryResponse">
         SELECT wd.id AS winnerDealId,
+               wd.deal_number AS dealNumber,
                wd.auction_id AS auctionId,
                ai.id AS itemId,
                ai.name AS itemName,
@@ -161,6 +167,7 @@
     <!-- 판매내역 조회 -->
     <select id="findSaleHistory" resultType="WinnerDealHistoryResponse">
         SELECT wd.id AS winnerDealId,
+               wd.deal_number AS dealNumber,
                wd.auction_id AS auctionId,
                ai.id AS itemId,
                ai.name AS itemName,
@@ -193,8 +200,74 @@
         <include refid="winnerDealHistoryStatusFilter"/>
     </select>
 
+    <sql id="adminWinnerDealHistoryFilter">
+        <if test="request.dealNumber != null and request.dealNumber != ''">
+            AND wd.deal_number = #{request.dealNumber}
+        </if>
+        <if test="request.status != null">
+            <choose>
+                <when test="request.status.name() == 'PAID'">
+                    AND wd.status = 'PAID'
+                    AND wd.delivery_status = 'SHIPPED'
+                    AND wd.tracking_number IS NULL
+                </when>
+                <when test="request.status.name() == 'SHIPPED'">
+                    AND wd.status = 'PAID'
+                    AND wd.delivery_status = 'SHIPPED'
+                    AND wd.tracking_number IS NOT NULL
+                </when>
+                <when test="request.status.name() == 'DELIVERED'">
+                    AND wd.status = 'PAID'
+                    AND wd.delivery_status = 'DELIVERED'
+                </when>
+                <when test="request.status.name() == 'CONFIRMED'">
+                    AND wd.status = 'CONFIRMED'
+                </when>
+                <when test="request.status.name() == 'CANCELLED'">
+                    AND wd.status = 'CANCELLED'
+                </when>
+            </choose>
+        </if>
+    </sql>
+
+    <select id="findAdminWinnerDealHistory" resultType="AdminWinnerDealListResponse">
+        SELECT wd.deal_number AS dealNumber,
+               seller.nickname AS sellerName,
+               winner.nickname AS winnerName,
+               ai.name AS itemName,
+               wd.winner_price AS winnerPrice,
+               wd.created_at AS createdAt,
+               CASE
+                   WHEN wd.status = 'CANCELLED' THEN 'CANCELLED'
+                   WHEN wd.status = 'CONFIRMED' THEN 'CONFIRMED'
+                   WHEN wd.delivery_status = 'DELIVERED' THEN 'DELIVERED'
+                   WHEN wd.tracking_number IS NOT NULL THEN 'SHIPPED'
+                   ELSE 'PAID'
+               END AS status
+        FROM winner_deal wd
+        JOIN auction a ON wd.auction_id = a.id
+        JOIN auction_item ai ON a.item_id = ai.id
+        JOIN member seller ON seller.id = wd.seller_id
+        JOIN member winner ON winner.id = wd.winner_id
+        WHERE 1 = 1
+        <include refid="adminWinnerDealHistoryFilter"/>
+        ORDER BY wd.created_at ${order}
+    </select>
+
+    <select id="countAdminWinnerDealHistory" resultType="long">
+        SELECT COUNT(*)
+        FROM winner_deal wd
+        JOIN auction a ON wd.auction_id = a.id
+        JOIN auction_item ai ON a.item_id = ai.id
+        JOIN member seller ON seller.id = wd.seller_id
+        JOIN member winner ON winner.id = wd.winner_id
+        WHERE 1 = 1
+        <include refid="adminWinnerDealHistoryFilter"/>
+    </select>
+
     <select id="findWinnerDealDetail" resultType="WinnerDealDetailQueryResult">
         SELECT wd.id AS winnerDealId,
+               wd.deal_number AS dealNumber,
                wd.auction_id AS auctionId,
                ai.id AS itemId,
                wd.winner_id AS winnerId,

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -115,7 +115,7 @@
     <!-- 관리자 거래 내역 조회 시 필터링 조각 -->
     <sql id="adminWinnerDealHistoryFilter">
         <if test="request.dealNumber != null and request.dealNumber != ''">
-            AND wd.deal_number = #{request.dealNumber}
+            AND wd.deal_number LIKE CONCAT('%', #{request.dealNumber}, '%')
         </if>
         <if test="request.status != null">
             <choose>
@@ -284,4 +284,12 @@
         <include refid="adminWinnerDealHistoryFilter"/>
     </select>
 
+    <!-- 거래 번호가 존재하는지 여부 -->
+    <select id="existsByDealNumber" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+            FROM winner_deal
+            WHERE deal_number = #{dealNumber}
+        )
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 관리자 거래내역 조회 API를 추가했습니다.
- 관리자 거래내역 조회 시 상태 필터와 거래번호(`dealNumber`) 검색이 가능하도록 구현했습니다.
- `winner_deal`에 외부 노출용 거래번호 필드(`deal_number`)를 추가했습니다.
- 거래 생성 시 `dealNumber`가 함께 저장되도록 반영했습니다.
- `winner_deal`의 `status`와 `delivery_status`를 통합해 상태 관리 구조를 단순화했습니다.
- 거래 상태를 `PAID`, `SHIPPED`, `CONFIRMED`, `CANCELLED` 기준으로 정리했습니다.
- 구매/판매/관리자 거래내역 조회 로직이 통합된 상태값 기준으로 동작하도록 수정했습니다.
- `winnerdeal` 조회 DTO의 상태 필드를 enum(`WinnerDealStatus`) 기준으로 정리했습니다.

---

## 📎 관련 이슈
- #196