### PR TITLE
feat: 관리자 거래내역 상세조회 및 검수 물품 운송장 등록 API 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/AdminWinnerDealController.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/controller/AdminWinnerDealController.java
@@ -2,10 +2,14 @@ package com.biddingmate.biddinggo.winnerdeal.controller;
 
 import com.biddingmate.biddinggo.common.response.ApiResponse;
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.service.WinnerDealQueryService;
+import com.biddingmate.biddinggo.winnerdeal.service.WinnerDealService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +17,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Admin-Winner-Deal", description = "관리자 거래 관리 API")
 public class AdminWinnerDealController {
     private final WinnerDealQueryService winnerDealQueryService;
+    private final WinnerDealService winnerDealService;
 
     @GetMapping("")
     @PreAuthorize("hasRole('ADMIN')")
@@ -30,5 +38,23 @@ public class AdminWinnerDealController {
         PageResponse<AdminWinnerDealListResponse> result = winnerDealQueryService.findAdminWinnerDealHistory(request);
 
         return ApiResponse.of(HttpStatus.OK, null, "관리자 거래 내역 조회에 성공했습니다.", result);
+    }
+    @GetMapping("/{winnerDealId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "관리자 거래 상세 조회", description = "관리자가 거래 상세 정보와 구매자/판매자/배송 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<AdminWinnerDealDetailResponse>> findAdminWinnerDealDetail(@Parameter(description = "거래 ID", example = "1") @PathVariable Long winnerDealId) {
+        AdminWinnerDealDetailResponse result = winnerDealQueryService.findAdminWinnerDealDetail(winnerDealId);
+
+        return ApiResponse.of(HttpStatus.OK, null, "관리자 거래 상세 조회에 성공했습니다.", result);
+    }
+
+    @PatchMapping("/{winnerDealId}/tracking-number")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "관리자 검수 물품 운송장 등록", description = "관리자가 검수 물품 거래에 한해 운송장 정보를 등록합니다.")
+    public ResponseEntity<ApiResponse<Void>> registerTrackingNumber(@Parameter(description = "거래 ID", example = "1") @PathVariable Long winnerDealId,
+                                                                    @Valid @RequestBody WinnerDealTrackingNumberRequest request) {
+        winnerDealService.registerTrackingNumberByAdmin(winnerDealId, request);
+
+        return ApiResponse.of(HttpStatus.OK, null, "관리자 운송장 등록에 성공했습니다.", null);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailQueryResult.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailQueryResult.java
@@ -1,0 +1,31 @@
+package com.biddingmate.biddinggo.winnerdeal.dto;
+
+import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AdminWinnerDealDetailQueryResult {
+    private Long winnerDealId;
+    private String dealNumber;
+    private Long auctionId;
+    private Long itemId;
+    private String itemName;
+    private String itemImageUrl;
+    private AuctionType auctionType;
+    private WinnerDealStatus status;
+    private Long winnerPrice;
+    private String sellerName;
+    private String winnerName;
+    private String recipient;
+    private String tel;
+    private String zipcode;
+    private String address;
+    private String detailAddress;
+    private String carrier;
+    private String trackingNumber;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailResponse.java
@@ -1,0 +1,82 @@
+package com.biddingmate.biddinggo.winnerdeal.dto;
+
+import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "관리자 거래 상세 조회 응답")
+public class AdminWinnerDealDetailResponse {
+    @Schema(description = "거래 ID", example = "101")
+    private Long winnerDealId;
+
+    @Schema(description = "거래 번호", example = "WD-20260409-A1B2C3")
+    private String dealNumber;
+
+    @Schema(description = "경매 ID", example = "201")
+    private Long auctionId;
+
+    @Schema(description = "상품 ID", example = "301")
+    private Long itemId;
+
+    @Schema(description = "상품명", example = "롤렉스 시계")
+    private String itemName;
+
+    @Schema(description = "상품 이미지 URL", example = "https://cdn.example.com/item/1.jpg")
+    private String itemImageUrl;
+
+    @Schema(description = "경매 타입", example = "INSPECTION")
+    private AuctionType auctionType;
+
+    @Schema(description = "검수 물품 여부", example = "true")
+    private Boolean inspectionItem;
+
+    @Schema(description = "거래 상태", example = "PAID")
+    private WinnerDealStatus status;
+
+    @Schema(description = "거래 금액", example = "1500000")
+    private Long winnerPrice;
+
+    @Schema(description = "판매자 닉네임", example = "seller1")
+    private String sellerName;
+
+    @Schema(description = "구매자 닉네임", example = "buyer1")
+    private String winnerName;
+
+    @Schema(description = "수령인", example = "홍길동")
+    private String recipient;
+
+    @Schema(description = "연락처", example = "010-1234-5678")
+    private String tel;
+
+    @Schema(description = "우편번호", example = "06109")
+    private String zipcode;
+
+    @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 152")
+    private String address;
+
+    @Schema(description = "상세 주소", example = "강남파이낸스센터 12층")
+    private String detailAddress;
+
+    @Schema(description = "택배사", example = "CJ Logistics")
+    private String carrier;
+
+    @Schema(description = "운송장 번호", example = "1234567890")
+    private String trackingNumber;
+
+    @Schema(description = "관리자 운송장 등록 가능 여부", example = "false")
+    private Boolean canRegisterTrackingNumber;
+
+    @Schema(description = "구매 확정일", example = "2026-03-05T18:30:00")
+    private LocalDateTime confirmedAt;
+
+    @Schema(description = "거래 일시", example = "2026-03-03T14:00:00")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/mapper/WinnerDealMapper.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.winnerdeal.mapper;
 
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealHistoryRequest;
@@ -43,6 +44,7 @@ public interface WinnerDealMapper {
                                                                  @Param("request") AdminWinnerDealListRequest request,
                                                                  @Param("order") String order);
     long countAdminWinnerDealHistory(@Param("request") AdminWinnerDealListRequest request);
+    AdminWinnerDealDetailQueryResult findAdminWinnerDealDetail(@Param("winnerDealId") Long winnerDealId);
 
     // 거래 내역 상세 조회
     WinnerDealDetailQueryResult findWinnerDealDetail(@Param("winnerDealId") Long winnerDealId);

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryService.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.winnerdeal.service;
 
 import com.biddingmate.biddinggo.common.response.PageResponse;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailResponse;
@@ -26,4 +27,7 @@ public interface WinnerDealQueryService {
 
     // 관리자 거래 내역 조회
     PageResponse<AdminWinnerDealListResponse> findAdminWinnerDealHistory(@Valid AdminWinnerDealListRequest request);
+
+    // 관리자 거래 내역 상세 조회
+    AdminWinnerDealDetailResponse findAdminWinnerDealDetail(Long winnerDealId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -4,6 +4,9 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.review.mapper.ReviewMapper;
+import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailQueryResult;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealDetailQueryResult;
@@ -132,6 +135,47 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
         return PageResponse.of(content, request.getPage(), request.getSize(), totalElements);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public AdminWinnerDealDetailResponse findAdminWinnerDealDetail(Long winnerDealId) {
+        AdminWinnerDealDetailQueryResult detail = winnerDealMapper.findAdminWinnerDealDetail(winnerDealId);
+        if (detail == null) {
+            throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
+        }
+
+        boolean inspectionItem = detail.getAuctionType() == AuctionType.INSPECTION;
+        boolean shippingAddressRegistered = isShippingAddressRegistered(detail);
+        boolean trackingNumberRegistered = isTrackingNumberRegistered(detail);
+
+        return AdminWinnerDealDetailResponse.builder()
+                .winnerDealId(detail.getWinnerDealId())
+                .dealNumber(detail.getDealNumber())
+                .auctionId(detail.getAuctionId())
+                .itemId(detail.getItemId())
+                .itemName(detail.getItemName())
+                .itemImageUrl(detail.getItemImageUrl())
+                .auctionType(detail.getAuctionType())
+                .inspectionItem(inspectionItem)
+                .status(detail.getStatus())
+                .winnerPrice(detail.getWinnerPrice())
+                .sellerName(detail.getSellerName())
+                .winnerName(detail.getWinnerName())
+                .recipient(detail.getRecipient())
+                .tel(detail.getTel())
+                .zipcode(detail.getZipcode())
+                .address(detail.getAddress())
+                .detailAddress(detail.getDetailAddress())
+                .carrier(detail.getCarrier())
+                .trackingNumber(detail.getTrackingNumber())
+                .canRegisterTrackingNumber(inspectionItem
+                        && detail.getStatus() == WinnerDealStatus.PAID
+                        && shippingAddressRegistered
+                        && !trackingNumberRegistered)
+                .confirmedAt(detail.getConfirmedAt())
+                .createdAt(detail.getCreatedAt())
+                .build();
+    }
+
     private boolean isShippingAddressRegistered(WinnerDealDetailQueryResult detail) {
         // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
         return StringUtils.hasText(detail.getRecipient())
@@ -142,6 +186,18 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
 
     private boolean isTrackingNumberRegistered(WinnerDealDetailQueryResult detail) {
         // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
+        return StringUtils.hasText(detail.getCarrier())
+                && StringUtils.hasText(detail.getTrackingNumber());
+    }
+
+    private boolean isShippingAddressRegistered(AdminWinnerDealDetailQueryResult detail) {
+        return StringUtils.hasText(detail.getRecipient())
+                && StringUtils.hasText(detail.getTel())
+                && StringUtils.hasText(detail.getZipcode())
+                && StringUtils.hasText(detail.getAddress());
+    }
+
+    private boolean isTrackingNumberRegistered(AdminWinnerDealDetailQueryResult detail) {
         return StringUtils.hasText(detail.getCarrier())
                 && StringUtils.hasText(detail.getTrackingNumber());
     }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealService.java
@@ -12,6 +12,7 @@ public interface WinnerDealService {
     void registerShippingAddress(Long winnerDealId, Long memberId, WinnerDealShippingAddressRequest request);
     // 판매자 운송장 번호 등록
     void registerTrackingNumber(Long winnerDealId, Long memberId, WinnerDealTrackingNumberRequest request);
+    void registerTrackingNumberByAdmin(Long winnerDealId, WinnerDealTrackingNumberRequest request);
     // 구매자 구매확정
     void confirmPurchase(Long winnerDealId, Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -4,6 +4,7 @@ import com.biddingmate.biddinggo.auction.dto.RefundDto;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auction.model.AuctionStatus;
+import com.biddingmate.biddinggo.auction.model.AuctionType;
 import com.biddingmate.biddinggo.auction.prediction.event.AuctionPriceReferenceSyncRequestedEvent;
 import com.biddingmate.biddinggo.bid.dto.BidResponse;
 import com.biddingmate.biddinggo.bid.mapper.BidMapper;
@@ -15,6 +16,7 @@ import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.point.service.PointService;
+import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
@@ -205,6 +207,28 @@ public class WinnerDealServiceImpl implements WinnerDealService {
 
     @Override
     @Transactional
+    public void registerTrackingNumberByAdmin(Long winnerDealId, WinnerDealTrackingNumberRequest request) {
+        AdminWinnerDealDetailQueryResult detail = winnerDealMapper.findAdminWinnerDealDetail(winnerDealId);
+
+        if (detail == null) {
+            throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
+        }
+
+        if (detail.getAuctionType() != AuctionType.INSPECTION
+                || detail.getStatus() != WinnerDealStatus.PAID
+                || !isShippingInfoRegistered(detail)
+                || isTrackingNumberRegistered(detail)) {
+            throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED);
+        }
+
+        int updatedRows = winnerDealMapper.updateTrackingNumber(winnerDealId, request);
+        if (updatedRows != 1) {
+            throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_SAVE_FAILED);
+        }
+    }
+
+    @Override
+    @Transactional
     public void confirmPurchase(Long winnerDealId, Long memberId) {
         WinnerDeal winnerDeal = winnerDealMapper.findById(winnerDealId);
 
@@ -286,6 +310,18 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
         return StringUtils.hasText(winnerDeal.getCarrier())
                 && StringUtils.hasText(winnerDeal.getTrackingNumber());
+    }
+
+    private boolean isShippingInfoRegistered(AdminWinnerDealDetailQueryResult detail) {
+        return StringUtils.hasText(detail.getRecipient())
+                && StringUtils.hasText(detail.getTel())
+                && StringUtils.hasText(detail.getZipcode())
+                && StringUtils.hasText(detail.getAddress());
+    }
+
+    private boolean isTrackingNumberRegistered(AdminWinnerDealDetailQueryResult detail) {
+        return StringUtils.hasText(detail.getCarrier())
+                && StringUtils.hasText(detail.getTrackingNumber());
     }
 
     private String generateDealNumber() {

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -16,7 +16,6 @@ import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
 import com.biddingmate.biddinggo.point.service.PointService;
-import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
@@ -208,16 +207,20 @@ public class WinnerDealServiceImpl implements WinnerDealService {
     @Override
     @Transactional
     public void registerTrackingNumberByAdmin(Long winnerDealId, WinnerDealTrackingNumberRequest request) {
-        AdminWinnerDealDetailQueryResult detail = winnerDealMapper.findAdminWinnerDealDetail(winnerDealId);
-
-        if (detail == null) {
+        WinnerDeal winnerDeal = winnerDealMapper.findById(winnerDealId);
+        if (winnerDeal == null) {
             throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
         }
 
-        if (detail.getAuctionType() != AuctionType.INSPECTION
-                || detail.getStatus() != WinnerDealStatus.PAID
-                || !isShippingInfoRegistered(detail)
-                || isTrackingNumberRegistered(detail)) {
+        Auction auction = auctionMapper.findById(winnerDeal.getAuctionId());
+        if (auction == null) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
+        }
+
+        if (auction.getType() != AuctionType.INSPECTION
+                || winnerDeal.getStatus() != WinnerDealStatus.PAID
+                || !isShippingInfoRegistered(winnerDeal)
+                || isTrackingNumberRegistered(winnerDeal)) {
             throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED);
         }
 
@@ -310,18 +313,6 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         // null, 빈 문자열, 공백만 있는 값은 미입력으로 본다.
         return StringUtils.hasText(winnerDeal.getCarrier())
                 && StringUtils.hasText(winnerDeal.getTrackingNumber());
-    }
-
-    private boolean isShippingInfoRegistered(AdminWinnerDealDetailQueryResult detail) {
-        return StringUtils.hasText(detail.getRecipient())
-                && StringUtils.hasText(detail.getTel())
-                && StringUtils.hasText(detail.getZipcode())
-                && StringUtils.hasText(detail.getAddress());
-    }
-
-    private boolean isTrackingNumberRegistered(AdminWinnerDealDetailQueryResult detail) {
-        return StringUtils.hasText(detail.getCarrier())
-                && StringUtils.hasText(detail.getTrackingNumber());
     }
 
     private String generateDealNumber() {

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -270,7 +270,9 @@
         JOIN auction_item ai ON a.item_id = ai.id
         JOIN member seller ON seller.id = wd.seller_id
         JOIN member winner ON winner.id = wd.winner_id
-        <include refid="adminWinnerDealHistoryFilter"/>
+        <where>
+            <include refid="adminWinnerDealHistoryFilter"/>
+        </where>
         ORDER BY wd.created_at DESC, wd.id DESC
     </select>
 
@@ -281,7 +283,9 @@
         JOIN auction_item ai ON a.item_id = ai.id
         JOIN member seller ON seller.id = wd.seller_id
         JOIN member winner ON winner.id = wd.winner_id
-        <include refid="adminWinnerDealHistoryFilter"/>
+        <where>
+            <include refid="adminWinnerDealHistoryFilter"/>
+        </where>
     </select>
 
     <!-- 거래 번호가 존재하는지 여부 -->
@@ -291,5 +295,37 @@
             FROM winner_deal
             WHERE deal_number = #{dealNumber}
         )
+    </select>
+
+    <!-- 관리자 거래 내역 상세 조회 -->
+    <select id="findAdminWinnerDealDetail" resultType="AdminWinnerDealDetailQueryResult">
+        SELECT wd.id AS winnerDealId,
+               wd.deal_number AS dealNumber,
+               wd.auction_id AS auctionId,
+               ai.id AS itemId,
+               ai.name AS itemName,
+               ii.url AS itemImageUrl,
+               a.type AS auctionType,
+               wd.status AS status,
+               wd.winner_price AS winnerPrice,
+               seller.nickname AS sellerName,
+               winner.nickname AS winnerName,
+               wd.recipient AS recipient,
+               wd.tel AS tel,
+               wd.zipcode AS zipcode,
+               wd.address AS address,
+               wd.detail_address AS detailAddress,
+               wd.carrier AS carrier,
+               wd.tracking_number AS trackingNumber,
+               wd.confirmed_at AS confirmedAt,
+               wd.created_at AS createdAt
+        FROM winner_deal wd
+        JOIN auction a ON wd.auction_id = a.id
+        JOIN auction_item ai ON a.item_id = ai.id
+        LEFT JOIN item_image ii ON ii.item_id = ai.id AND ii.display_order = 1
+        JOIN member seller ON seller.id = wd.seller_id
+        JOIN member winner ON winner.id = wd.winner_id
+        WHERE wd.id = #{winnerDealId}
+            LIMIT 1
     </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 관리자 거래내역 상세조회 API를 추가했습니다.
- 관리자 상세조회에서 거래 정보, 구매자 정보, 판매자 정보, 배송 정보를 함께 조회할 수 있도록 구현했습니다.
- 검수 물품 여부와 관리자 운송장 등록 가능 여부를 상세 응답에 포함하도록 반영했습니다.
- 검수 물품 거래에 한해 관리자가 운송장 번호를 등록할 수 있는 API를 추가했습니다.
- 운송장 등록 시 검수 물품 여부, 거래 상태, 배송지 등록 여부, 기존 운송장 등록 여부를 검증하도록 구현했습니다.

---

## 📎 관련 이슈
- #202