### PR TITLE
Feat/ SSE 및 Notification API 추가 및 수정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/bid/service/BidApplicationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/bid/service/BidApplicationServiceImpl.java
@@ -11,6 +11,8 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
 import com.biddingmate.biddinggo.member.service.MemberService;
+import com.biddingmate.biddinggo.notification.model.NotificationType;
+import com.biddingmate.biddinggo.notification.service.NotificationPublisher;
 import com.biddingmate.biddinggo.point.model.PointHistory;
 import com.biddingmate.biddinggo.point.model.PointHistoryType;
 import com.biddingmate.biddinggo.point.service.PointService;
@@ -34,11 +36,14 @@ public class BidApplicationServiceImpl implements BidApplicationService {
     private final MemberService memberService;
     private final PointService pointService;
     private final BidService bidService;
+    private final BidQueryService bidQueryService;
+    private final NotificationPublisher notificationPublisher;
 
     @Override
     @Transactional
     public CreateBidResponse createBidProcess(Long memberId, CreateBidRequest request){
         Long auctionId = request.getAuctionId();
+        Long preciousTopBidderId = bidQueryService.findTopBidderId(auctionId);
 
         // 1. 경매 유효성 검증
         Auction auction = auctionMapper.findByIdForUpdate(auctionId);
@@ -112,6 +117,32 @@ public class BidApplicationServiceImpl implements BidApplicationService {
 
         if (pointInsert != 1) {
             throw new CustomException(ErrorType.POINT_HISTORY_SAVE_FAILED);
+        }
+
+        // 입찰 알람
+        notificationPublisher.publishNotification(
+                auction.getSellerId(),
+                NotificationType.NEW_BID,
+                "경매 #" + auctionId + "에 새로운 입찰이 등록되었습니다.",
+                "/auctions/" + auctionId
+        );
+
+        Long currentTopBidderId = bidQueryService.findTopBidderId(auctionId);
+
+        // 알람 분기
+        // 현재 최고입찰자가 존재하고 그 최고 입찰자가 "지금 입찰한 사람이고" 이전에는 그 사람이 최고 입찰자가 아니었을 때
+        // 이번 입찰로 새롭게 1등이 된 경우만 최상위 입찰 알람을 보낸다. (원래 1등이던 사람이 금액만 올린 경우는 중복 알림 방지)
+        if (currentTopBidderId != null && currentTopBidderId.equals(memberId)
+                && (preciousTopBidderId == null || !preciousTopBidderId.equals(memberId))) {
+
+            // 최상위 입찰 알람
+            notificationPublisher.publishNotification(
+                    memberId,
+                    NotificationType.TOP_BID,
+                    "경매 #" + auctionId + "에서 현재 최상위 입찰자가 되었습니다.",
+                    "/auctions/" + auctionId
+            );
+
         }
 
         return CreateBidResponse.builder()

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -152,7 +152,7 @@ public enum ErrorType {
     SELLER_NOT_FOUND("review-006", "해당 경매의 판매자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 알림
-    NOTIFICATOIN_SAVE_FAILED("notification-001", "알림 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_SAVE_FAILED("notification-001", "알림 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 공지사항
     NOTICE_NOT_FOUND("notice-001", "해당 공지사항을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
 import com.biddingmate.biddinggo.notification.dto.CreateNotificationResponse;
 import com.biddingmate.biddinggo.notification.dto.NotificationResponse;
+import com.biddingmate.biddinggo.notification.dto.UnreadNotificationResponse;
 import com.biddingmate.biddinggo.notification.service.NotificationService;
 import com.biddingmate.biddinggo.notification.service.NotificationSseService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,6 +41,7 @@ public class NotificationController {
         모두 알림 등록 프로세스를 구현하면 (notificationService 를 사용하여)
         알림 등록 api 는 삭제 예정
      */
+
     @PostMapping("/")
     @Operation(summary = "알림 등록", description = "알림을 등록합니다.")
     public ResponseEntity<ApiResponse<CreateNotificationResponse>> createBid(
@@ -91,4 +93,18 @@ public class NotificationController {
     ) {
         return notificationSseService.subscribe(member.getId());
     }
+
+    @GetMapping("/unread-count")
+    @Operation(summary = "읽지 않은 알림 수 조회")
+    public ResponseEntity<ApiResponse<UnreadNotificationResponse>> getUnreadCount(
+            @AuthenticationPrincipal Member member
+    ) {
+
+        UnreadNotificationResponse result = UnreadNotificationResponse.builder()
+                .unreadCount(notificationService.countUnread(member.getId()))
+                .build();
+
+        return ApiResponse.of(HttpStatus.OK, null, "읽지 않은 알림 수 조회 성공", result);
+    }
+
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/dto/UnreadNotificationResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/dto/UnreadNotificationResponse.java
@@ -1,0 +1,14 @@
+package com.biddingmate.biddinggo.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UnreadNotificationResponse {
+    private int unreadCount;
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/mapper/NotificationMapper.java
@@ -21,4 +21,6 @@ public interface NotificationMapper extends IMybatisCRUD<Notification> {
     void updateReadAtByMemberId(@Param("receiverId") Long receiverId);
 
     void updateReadAtById(@Param("id") Long id, @Param("receiverId") Long receiverId);
+
+    int countUnreadByReceiverId(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/model/Notification.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/model/Notification.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class Notification {
+
     private Long id;
     private Long receiverId;
     private NotificationType type;

--- a/src/main/java/com/biddingmate/biddinggo/notification/model/NotificationType.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/model/NotificationType.java
@@ -2,5 +2,8 @@ package com.biddingmate.biddinggo.notification.model;
 
 public enum NotificationType {
     DELIVERY,
-    WIN
+    WIN,
+    NEW_BID,
+    TOP_BID,
+    AUCTION_UNSOLD
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationPublisher.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationPublisher.java
@@ -1,0 +1,34 @@
+package com.biddingmate.biddinggo.notification.service;
+
+import com.biddingmate.biddinggo.notification.dto.CreateNotificationRequest;
+import com.biddingmate.biddinggo.notification.model.NotificationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationPublisher {
+
+    private final NotificationService notificationService;
+
+    // 알람 발신을 위한 매서드
+    public void publishNotification(Long receiverId, NotificationType type, String content, String url) {
+
+        try {
+            notificationService.createNotification(
+                    CreateNotificationRequest.builder()
+                            .receiverId(receiverId)
+                            .type(type)
+                            .content(content)
+                            .url(url)
+                            .build()
+            );
+        } catch (Exception e) {
+
+            log.warn("[notification-failed] receiverId={}, type={}", receiverId, type, e);
+        }
+    }
+
+}

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationService.java
@@ -15,4 +15,6 @@ public interface NotificationService{
     void markAllAsRead(Long receiverId);
 
     void markAsRead(Long id, Long receiverId);
+
+    int countUnread(Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
@@ -44,7 +44,7 @@ public class NotificationServiceImpl implements NotificationService {
         int result = notificationMapper.insert(notification);
 
         if(result != 1 || notification.getId() == null){
-            throw new CustomException(ErrorType.NOTIFICATOIN_SAVE_FAILED);
+            throw new CustomException(ErrorType.NOTIFICATION_SAVE_FAILED);
         }
 
         NotificationResponse response = NotificationResponse.builder()

--- a/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/service/NotificationServiceImpl.java
@@ -64,6 +64,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public PageResponse<NotificationResponse> getNotificationsByMemberId(BasePageRequest request, Long receiverId) {
+
         RowBounds rowBounds = new RowBounds(request.getOffset(), request.getSize());
         String order = request.getOrder();
 
@@ -87,5 +88,11 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public void markAsRead(Long id, Long receiverId) {
         notificationMapper.updateReadAtById(id, receiverId);
+    }
+
+    @Override
+    public int countUnread(Long memberId) {
+
+        return notificationMapper.countUnreadByReceiverId(memberId);
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -14,6 +14,8 @@ import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
+import com.biddingmate.biddinggo.notification.model.NotificationType;
+import com.biddingmate.biddinggo.notification.service.NotificationPublisher;
 import com.biddingmate.biddinggo.point.service.PointService;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
@@ -49,6 +51,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
     private final AuctionItemMapper auctionItemMapper;
     private final PointService pointService;
     private final ApplicationEventPublisher eventPublisher;
+    private final NotificationPublisher notificationPublisher;
 
     @Override
     @Transactional
@@ -104,6 +107,15 @@ public class WinnerDealServiceImpl implements WinnerDealService {
             log.info("낙찰 처리 성공 - Auction ID: {}, Winner: {}, Price: {}",
                     auction.getId(), winnerBid.getBidderId(), finalPrice);
 
+            // 낙찰 알람
+            notificationPublisher.publishNotification(
+                    winnerBid.getBidderId(),
+                    NotificationType.WIN,
+                    "축하합니다. 경매 #" + auction.getId() + " 낙찰이 확정되었습니다.",
+                    "/auctions/" + auction.getId()
+            );
+
+
             List<RefundDto> refunds =
                     bidQueryService.findRefundTargetsExcludingWinner(auction.getId(), winnerBid.getBidderId());
 
@@ -127,6 +139,15 @@ public class WinnerDealServiceImpl implements WinnerDealService {
                     null
             );
             log.info("유찰 처리 완료 - Auction ID: {}", auction.getId());
+
+            // 유찰 알람
+            notificationPublisher.publishNotification(
+                    auction.getSellerId(),
+                    NotificationType.AUCTION_UNSOLD,
+                    "경매 #" + auction.getId() + "가 유찰되었습니다.",
+                    "/auctions/" + auction.getId()
+            );
+
         }
     }
 
@@ -201,6 +222,16 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         if (updatedRows != 1) {
             throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_SAVE_FAILED);
         }
+
+        notificationPublisher.publishNotification(
+                winnerDeal.getWinnerId(),
+                NotificationType.DELIVERY,
+                "상품이 발송되었습니다. 운송사: " + request.getCarrier() + ", 송장번호 : " + request.getTrackingNumber(),
+                "/winner-deals/" + winnerDealId
+        );
+
+
+
     }
 
     @Override

--- a/src/main/resources/mapper/notification/notification-mapper.xml
+++ b/src/main/resources/mapper/notification/notification-mapper.xml
@@ -37,6 +37,13 @@
         WHERE receiver_id = #{receiverId}
     </select>
 
+    <select id="countUnreadByReceiverId" resultType="_int">
+        SELECT COUNT(*)
+        FROM notification
+        WHERE receiver_id = #{receiverId}
+          AND read_at IS NULL
+    </select>
+
     <update id="updateReadAtByMemberId">
         UPDATE notification
         SET read_at = NOW()


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 알림 도메인 연동을 위한 공통 발행 컴포넌트 NotificationPublisher 추가
- unread-count 기능 추가
- 입찰 도메인 알림 연동 (BidApplicationServiceImpl) / 
- 새입찰시 NEW_BID (판매자만)
- 최상위 입찰시 TOP_BID (입찰자 본인만)
- 경매 마감/거래 도메인 알림 연동 (WinnerDealServiceImpl) 
- 낙찰시 WIN (해당 낙찰자)
- 유찰시 AUCTION_UNSOLD (판매자만) 
- 배송시 구매자만 DELIVERY (낙찰자만)


---

## 📎 관련 이슈
닫고 싶은 이슈가 있다면 아래에 키워드로 연결하세요.

예: `close #123`, `fixes #45`, `resolves #67`
