### PR TITLE
feat: 경매 관리 조회 API 수정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -7,11 +7,14 @@ import com.biddingmate.biddinggo.member.dto.MemberDashboardResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResultResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellerProfileResponse;
-import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -78,17 +81,26 @@ public class MemberController {
         return ApiResponse.of(HttpStatus.OK, null, "구매 내역 조회 성공", result);
     }
 
-    @GetMapping("/me/auctions")
-    public ResponseEntity<ApiResponse<PageResponse<MemberSellingItemResponse>>> getSellingItems(
+    @Operation(
+            summary = "경매관리",
+            description = "로그인한 회원의 경매를 상태별(ALL, ONGOING, SUCCESS, FAILED)로 조회합니다."
+    )
+    @GetMapping("/me/sales/auctions")
+    public ResponseEntity<ApiResponse<MemberSalesAuctionResultResponse>> getSellingItems(
             @AuthenticationPrincipal Member member,
-            @RequestParam String status,
+            @Parameter(
+                    description = "조회 타입(ALL, ONGOING, SUCCESS, FAILED)",
+                    example = "ONGOING"
+            )
+            @RequestParam String type,
             @Valid BasePageRequest pageRequest
     ) {
-        PageResponse<MemberSellingItemResponse> result =
-                memberService.getMySellingItems(member.getId(), status, pageRequest);
+        MemberSalesAuctionResultResponse result =
+                memberService.getMySalesAuctions(member.getId(), type, pageRequest);
 
-        return ApiResponse.of(HttpStatus.OK, null, "판매 중인 상품 조회 성공", result);
+        return ApiResponse.of(HttpStatus.OK, null, "경매 관리 목록 조회 성공", result);
     }
+
     @GetMapping("/{sellerId}")
     public ResponseEntity<ApiResponse<MemberSellerProfileResponse>> getSellerProfile(
             @PathVariable Long sellerId

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesAuctionResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesAuctionResponse.java
@@ -5,11 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MemberSellingItemResponse {
+public class MemberSalesAuctionResponse {
 
     // 상품명
     private String itemName;
@@ -23,12 +25,18 @@ public class MemberSellingItemResponse {
     // 입찰 수
     private Integer bidCount;
 
-    // 남은 시간(초)
-    private Long remainingSeconds;
+    // 종료 날짜
+    private LocalDateTime endDate;
 
-    // 경매 타입
+    // 경매 타입 (NORMAL, TIME_DEAL, INSPECTION)
     private String auctionType;
 
     // 대표 이미지 URL
     private String imageUrl;
+
+    // 판매 상태 (ONGOING, SUCCESS, FAILED)
+    private String saleStatus;
+
+    // 경매 ID
+    private Long auctionId;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesAuctionResultResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesAuctionResultResponse.java
@@ -1,0 +1,20 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import com.biddingmate.biddinggo.common.response.PageResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberSalesAuctionResultResponse {
+
+    // 전체 경매, 진행중, 낙찰, 유찰 개수
+    private MemberSalesAuctionSummaryResponse summary;
+
+    // 경매 목록
+    private PageResponse<MemberSalesAuctionResponse> auctions;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesAuctionSummaryResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesAuctionSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.biddingmate.biddinggo.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberSalesAuctionSummaryResponse {
+
+    // 전체 경매 개수
+    private Long totalCount;
+
+    // 진행중 개수
+    private Long ongoingCount;
+
+    // 낙찰 개수
+    private Long successCount;
+
+    // 유찰 개수
+    private Long failedCount;
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -9,9 +9,10 @@ import com.biddingmate.biddinggo.member.dto.MemberListView;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionSummaryResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellerProfileResponse;
-import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.member.model.MemberStatus;
@@ -81,13 +82,13 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
     // 총 구매 개수 조회
     long countPurchasesByMemberId(@Param("memberId") Long memberId);
 
-    List<MemberSellingItemResponse> findSellingItemsByMemberId(
+    List<MemberSalesAuctionResponse> findMySalesAuctions(
             @Param("memberId") Long memberId,
-            @Param("status") String upperCase,
+            @Param("type") String type,
             @Param("pageRequest") BasePageRequest pageRequest
     );
 
-    long countSellingItemsByMemberId(@Param("memberId") Long memberId, @Param("status") String upperCase);
+    long countMySalesAuctions(@Param("memberId") Long memberId, @Param("type") String type);
 
     List<MemberListView> findAllWithFilter(RowBounds rowBounds, String sortOrder, String keyword, MemberStatus status);
     int countTotalMember(String keyword, MemberStatus status);
@@ -106,4 +107,5 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
     // 거래 미완료 존재 여부
     boolean existsIncompleteDeals(@Param("memberId") Long memberId);
 
+    MemberSalesAuctionSummaryResponse countMySalesAuctionSummary(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -8,9 +8,10 @@ import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResultResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellerProfileResponse;
-import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResponse;
 import com.biddingmate.biddinggo.member.dto.UpdateMemberStatusRequest;
 import jakarta.validation.Valid;
 
@@ -31,7 +32,7 @@ public interface MemberService {
     void addPoint(Long memberId, Long amount);
     void deductPoint(Long memberId, Long amount);
 
-    PageResponse<MemberSellingItemResponse> getMySellingItems(Long memberId, String status, BasePageRequest pageRequest);
+    MemberSalesAuctionResultResponse getMySalesAuctions(Long memberId, String type, BasePageRequest pageRequest);
 
     PageResponse<MemberListView> findAllMemberWithFilter(@Valid MemberListViewRequest request);
     void updateMemberStatus(Long memberId, @Valid UpdateMemberStatusRequest request);

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -11,9 +11,11 @@ import com.biddingmate.biddinggo.member.dto.MemberListViewRequest;
 import com.biddingmate.biddinggo.member.dto.MemberProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberProfileUpdateRequest;
 import com.biddingmate.biddinggo.member.dto.MemberPurchaseItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResultResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionSummaryResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellerProfileResponse;
-import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
+import com.biddingmate.biddinggo.member.dto.MemberSalesAuctionResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.dto.UpdateMemberStatusRequest;
 import com.biddingmate.biddinggo.member.event.MemberStatusUpdateEvent;
@@ -195,35 +197,43 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public PageResponse<MemberSellingItemResponse> getMySellingItems(Long memberId, String status, BasePageRequest pageRequest) {
+    public MemberSalesAuctionResultResponse getMySalesAuctions(Long memberId, String type, BasePageRequest pageRequest) {
 
         // 회원 존재 여부 확인
         memberExists(memberId);
 
         // 상태값 검증
-        if (!"ON_GOING".equalsIgnoreCase(status)) {
-            throw new CustomException(ErrorType.INVALID_AUCTION_STATUS);
-        }
+        validateSalesAuctionStatus(type);
 
         // 정렬값은 최신순으로
         if (pageRequest.getOrder() == null || pageRequest.getOrder().isBlank()) {
             pageRequest.setOrder("DESC");
         }
 
-        // 판매중 상품 목록 조회
-        List<MemberSellingItemResponse> content =
-                memberMapper.findSellingItemsByMemberId(memberId, status.toUpperCase(), pageRequest);
+        String normalizedStatus = type.toUpperCase();
 
-        // 전체 개수 조회
+        // 판매 상품 목록 조회
+        List<MemberSalesAuctionResponse> content =
+                memberMapper.findMySalesAuctions(memberId, normalizedStatus, pageRequest);
+
+        // 현재 선택한 상태 기준, 전체 개수 조회
         long totalElements =
-                memberMapper.countSellingItemsByMemberId(memberId, status.toUpperCase());
+                memberMapper.countMySalesAuctions(memberId, normalizedStatus);
 
-        return PageResponse.of(
+        PageResponse<MemberSalesAuctionResponse> auctions = PageResponse.of(
                 content,
                 pageRequest.getPage(),
                 pageRequest.getSize(),
                 totalElements
         );
+
+        MemberSalesAuctionSummaryResponse summary =
+                memberMapper.countMySalesAuctionSummary(memberId);
+
+        return MemberSalesAuctionResultResponse.builder()
+                .summary(summary)
+                .auctions(auctions)
+                .build();
     }
 
     @Override
@@ -326,5 +336,20 @@ public class MemberServiceImpl implements MemberService {
         }
 
         return stats;
+    }
+
+    private void validateSalesAuctionStatus(String status) {
+        if (status == null || status.isBlank()) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_STATUS);
+        }
+
+        String normalizedStatus = status.toUpperCase();
+
+        if (!"ALL".equals(normalizedStatus)
+                && !"ONGOING".equals(normalizedStatus)
+                && !"SUCCESS".equals(normalizedStatus)
+                && !"FAILED".equals(normalizedStatus)) {
+            throw new CustomException(ErrorType.INVALID_AUCTION_STATUS);
+        }
     }
 }

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -389,46 +389,46 @@
       AND wd.status IN ('PAID', 'CONFIRMED')
 </select>
 
-    <select id="findSellingItemsByMemberId" resultType="MemberSellingItemResponse">
-        SELECT
-        ai.name AS itemName,                                  -- 상품명
-        COALESCE(a.vickrey_price, a.start_price) AS currentPrice, -- 현재 최고가
-        a.start_price AS startPrice,                          -- 시작가
-        a.bid_count AS bidCount,                              -- 입찰 수
-        TIMESTAMPDIFF(SECOND, NOW(), a.end_date) AS remainingSeconds, -- 남은 시간(초)
-        a.type AS auctionType,                                -- 경매 타입
-        ii.url AS imageUrl                                    -- 대표 이미지 URL
-        FROM auction a
+<!--    <select id="findSellingItemsByMemberId" resultType="MemberSellingItemResponse">-->
+<!--        SELECT-->
+<!--        ai.name AS itemName,                                  &#45;&#45; 상품명-->
+<!--        COALESCE(a.vickrey_price, a.start_price) AS currentPrice, &#45;&#45; 현재 최고가-->
+<!--        a.start_price AS startPrice,                          &#45;&#45; 시작가-->
+<!--        a.bid_count AS bidCount,                              &#45;&#45; 입찰 수-->
+<!--        TIMESTAMPDIFF(SECOND, NOW(), a.end_date) AS remainingSeconds, &#45;&#45; 남은 시간(초)-->
+<!--        a.type AS auctionType,                                &#45;&#45; 경매 타입-->
+<!--        ii.url AS imageUrl                                    &#45;&#45; 대표 이미지 URL-->
+<!--        FROM auction a-->
 
-        INNER JOIN auction_item ai
-        ON a.item_id = ai.id
+<!--        INNER JOIN auction_item ai-->
+<!--        ON a.item_id = ai.id-->
 
-        LEFT JOIN item_image ii
-        ON ii.item_id = ai.id
-        AND ii.display_order = 1
+<!--        LEFT JOIN item_image ii-->
+<!--        ON ii.item_id = ai.id-->
+<!--        AND ii.display_order = 1-->
 
-        WHERE a.seller_id = #{memberId}
-        AND a.status = #{status}
+<!--        WHERE a.seller_id = #{memberId}-->
+<!--        AND a.status = #{status}-->
 
-        <choose>
-            <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">
-                ORDER BY a.end_date ASC
-            </when>
-            <otherwise>
-                ORDER BY a.end_date DESC
-            </otherwise>
-        </choose>
+<!--        <choose>-->
+<!--            <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">-->
+<!--                ORDER BY a.end_date ASC-->
+<!--            </when>-->
+<!--            <otherwise>-->
+<!--                ORDER BY a.end_date DESC-->
+<!--            </otherwise>-->
+<!--        </choose>-->
 
-        LIMIT #{pageRequest.size}
-        OFFSET #{pageRequest.offset}
-    </select>
+<!--        LIMIT #{pageRequest.size}-->
+<!--        OFFSET #{pageRequest.offset}-->
+<!--    </select>-->
 
-    <select id="countSellingItemsByMemberId" resultType="long">
-        SELECT COUNT(*)
-        FROM auction a
-        WHERE a.seller_id = #{memberId}
-          AND a.status = #{status}
-    </select>
+<!--    <select id="countSellingItemsByMemberId" resultType="long">-->
+<!--        SELECT COUNT(*)-->
+<!--        FROM auction a-->
+<!--        WHERE a.seller_id = #{memberId}-->
+<!--          AND a.status = #{status}-->
+<!--    </select>-->
 
     <!-- 관리자용 모든 사용자 계정 조회 -->
     <select id="findAllWithFilter" resultType="MemberListView">
@@ -552,5 +552,72 @@
         )
     </select>
 
+<!--    경매 목록 조회-->
+    <select id="findMySalesAuctions" resultType="MemberSalesAuctionResponse">
+        SELECT
+        a.id AS auctionId,
+        ai.name AS itemName,
+        COALESCE(a.winner_price, a.vickrey_price, a.start_price) AS currentPrice,
+        a.start_price AS startPrice,
+        a.bid_count AS bidCount,
+        a.end_date AS endDate,
+        a.type AS auctionType,
+        CASE
+        WHEN a.status = 'ON_GOING' THEN 'ONGOING'
+        WHEN a.status = 'ENDED' AND a.winner_id IS NOT NULL THEN 'SUCCESS'
+        WHEN a.status = 'ENDED' AND a.winner_id IS NULL THEN 'FAILED'
+        END AS saleStatus,
+        ii.url AS imageUrl
+        FROM auction a
+        INNER JOIN auction_item ai
+        ON a.item_id = ai.id
+        LEFT JOIN item_image ii
+        ON ii.item_id = ai.id
+        AND ii.display_order = 1
+        WHERE a.seller_id = #{memberId}
+        AND a.status != 'CANCELLED'
+        AND (
+        #{type} = 'ALL'
+        OR (#{type} = 'ONGOING' AND a.status = 'ON_GOING')
+        OR (#{type} = 'SUCCESS' AND a.status = 'ENDED' AND a.winner_id IS NOT NULL)
+        OR (#{type} = 'FAILED' AND a.status = 'ENDED' AND a.winner_id IS NULL)
+        )
+        <choose>
+            <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">
+                ORDER BY a.created_at ASC
+            </when>
+            <otherwise>
+                ORDER BY a.created_at DESC
+            </otherwise>
+        </choose>
+        LIMIT #{pageRequest.size}
+        OFFSET #{pageRequest.offset}
+    </select>
+
+<!--    경매 개수 조회-->
+    <select id="countMySalesAuctions" resultType="long">
+        SELECT COUNT(*)
+        FROM auction a
+        WHERE a.seller_id = #{memberId}
+          AND a.status != 'CANCELLED'
+      AND (
+            #{type} = 'ALL'
+           OR (#{type} = 'ONGOING' AND a.status = 'ON_GOING')
+           OR (#{type} = 'SUCCESS' AND a.status = 'ENDED' AND a.winner_id IS NOT NULL)
+           OR (#{type} = 'FAILED' AND a.status = 'ENDED' AND a.winner_id IS NULL)
+            )
+    </select>
+
+<!--    총 경매 상품 개수, 경매 진행 중인 상품 개수, 낙찰 상품 개수, 유찰 상품 개수-->
+    <select id="countMySalesAuctionSummary" resultType="MemberSalesAuctionSummaryResponse">
+        SELECT
+            COUNT(*) AS totalCount,
+            SUM(CASE WHEN a.status = 'ON_GOING' THEN 1 ELSE 0 END) AS ongoingCount,
+            SUM(CASE WHEN a.status = 'ENDED' AND a.winner_id IS NOT NULL THEN 1 ELSE 0 END) AS successCount,
+            SUM(CASE WHEN a.status = 'ENDED' AND a.winner_id IS NULL THEN 1 ELSE 0 END) AS failedCount
+        FROM auction a
+        WHERE a.seller_id = #{memberId}
+          AND a.status != 'CANCELLED'
+    </select>
 </mapper>
 


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 조회 타입(전체`ALL`, 경매 진행 중`ONGOING`, 낙찰`SUCCESS`, 유찰`FAILED`)에 따른 상태별 조회 기능 추가
- 응답 구조를 리스트 + 상태별 집계(summary) 형태로 변경
  - 전체 개수, 진행 중, 낙찰, 유찰 개수 포함
- 기존 DTO(MemberSellingItemResponse) 제거 및 새로운 DTO 구조로 재구성
  - `MemberSalesAuctionResponse`
  - `MemberSalesAuctionResultResponse`
  - `MemberSalesAuctionSummaryResponse`
- 남은 시간 계산 방식 제거 후 `endDate` 반환 방식으로 변경
- mapper 및 쿼리 로직 수정 (상태 필터링 및 집계 쿼리 추가)

---

## 📎 관련 이슈

- close #206 
