### PR TITLE
feat: 회원 거래 완료 건수 기반 등급 재산정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -13,6 +13,7 @@ import com.biddingmate.biddinggo.member.dto.MemberSalesItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellerProfileResponse;
 import com.biddingmate.biddinggo.member.dto.MemberSellingItemResponse;
 import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
+import com.biddingmate.biddinggo.member.model.MemberGrade;
 import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.member.model.MemberStatus;
 import org.apache.ibatis.annotations.Mapper;
@@ -106,4 +107,10 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
     // 거래 미완료 존재 여부
     boolean existsIncompleteDeals(@Param("memberId") Long memberId);
 
+    // 사용자 VIP 등급 재산정을 위한 거래 건수 측정
+    long countConfirmedDealsByMemberId(@Param("memberId") Long memberId);
+
+    // 사용자 VIP 등급 재산정
+    void updateMemberGrade(@Param("memberId") Long memberId,
+                           @Param("grade") MemberGrade grade);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/model/MemberGrade.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/model/MemberGrade.java
@@ -1,0 +1,7 @@
+package com.biddingmate.biddinggo.member.model;
+
+public enum MemberGrade {
+    BRONZE,
+    SILVER,
+    GOLD
+}

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberService.java
@@ -36,4 +36,7 @@ public interface MemberService {
     PageResponse<MemberListView> findAllMemberWithFilter(@Valid MemberListViewRequest request);
     void updateMemberStatus(Long memberId, @Valid UpdateMemberStatusRequest request);
     MemberSellerProfileResponse getSellerProfile(Long sellerId);
+
+    // 사용자 VIP 등급 재산정
+    void recalculateMemberGrade(Long memberId);
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -18,6 +18,7 @@ import com.biddingmate.biddinggo.member.dto.MemberWonItemResponse;
 import com.biddingmate.biddinggo.member.dto.UpdateMemberStatusRequest;
 import com.biddingmate.biddinggo.member.event.MemberStatusUpdateEvent;
 import com.biddingmate.biddinggo.member.mapper.MemberMapper;
+import com.biddingmate.biddinggo.member.model.MemberGrade;
 import com.biddingmate.biddinggo.member.model.Member;
 import com.biddingmate.biddinggo.member.model.MemberStatus;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,9 @@ import java.util.Objects;
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
+    private static final long SILVER_MIN_CONFIRMED_DEAL_COUNT = 5L;
+    private static final long GOLD_MIN_CONFIRMED_DEAL_COUNT = 20L;
+
     private final MemberMapper memberMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -326,5 +330,28 @@ public class MemberServiceImpl implements MemberService {
         }
 
         return stats;
+    }
+
+    @Override
+    @Transactional
+    public void recalculateMemberGrade(Long memberId) {
+        getMember(memberId);
+
+        long confirmedDealCount = memberMapper.countConfirmedDealsByMemberId(memberId);
+        MemberGrade grade = resolveMemberGrade(confirmedDealCount);
+
+        memberMapper.updateMemberGrade(memberId, grade);
+    }
+
+    private MemberGrade resolveMemberGrade(long confirmedDealCount) {
+        if (confirmedDealCount >= GOLD_MIN_CONFIRMED_DEAL_COUNT) {
+            return MemberGrade.GOLD;
+        }
+
+        if (confirmedDealCount >= SILVER_MIN_CONFIRMED_DEAL_COUNT) {
+            return MemberGrade.SILVER;
+        }
+
+        return MemberGrade.BRONZE;
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -15,6 +15,7 @@ import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
+import com.biddingmate.biddinggo.member.service.MemberService;
 import com.biddingmate.biddinggo.point.service.PointService;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealShippingAddressRequest;
 import com.biddingmate.biddinggo.winnerdeal.dto.WinnerDealTrackingNumberRequest;
@@ -48,6 +49,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
     private final WinnerDealMapper winnerDealMapper;
     private final WinnerDealQueryService winnerDealQueryService;
     private final AuctionItemMapper auctionItemMapper;
+    private final MemberService memberService;
     private final PointService pointService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -267,6 +269,10 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         }
 
         pointService.settleWinnerDeal(winnerDeal.getSellerId(), winnerDeal.getWinnerPrice());
+
+        // 사용자 VIP 등급 재산정
+        memberService.recalculateMemberGrade(winnerDeal.getWinnerId());
+        memberService.recalculateMemberGrade(winnerDeal.getSellerId());
     }
 
     private void refundAndCancelWinnerDeal(WinnerDeal winnerDeal) {

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -552,5 +552,20 @@
         )
     </select>
 
+    <!-- 사용자 VIP 등급 재산정을 위한 거래 건수 측정 -->
+    <select id="countConfirmedDealsByMemberId" resultType="long">
+        SELECT COUNT(*)
+        FROM winner_deal
+        WHERE status = 'CONFIRMED'
+          AND (winner_id = #{memberId} OR seller_id = #{memberId})
+    </select>
+
+    <!-- 사용자 VIP 등급 재산정 -->
+    <update id="updateMemberGrade">
+        UPDATE member
+        SET grade = #{grade}
+        WHERE id = #{memberId}
+    </update>
+
 </mapper>
 


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 거래 완료 건수 기준 회원 등급 산정 로직을 추가했습니다.
- 회원 등급을 `BRONZE`, `SILVER`, `GOLD` 기준으로 계산하도록 구현했습니다.
- `winner_deal.status = CONFIRMED` 거래를 기준으로 완료 거래 건수를 집계하도록 반영했습니다.
- 구매확정 시점에 구매자와 판매자의 등급이 재산정되도록 연결했습니다.
- 회원 등급 집계 및 등급 업데이트를 위한 mapper 쿼리를 추가했습니다.

---

## 📎 관련 이슈
- #204