### PR TITLE
feat: 경매 관리 조회에 경매 예정, 취소 type 추가

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -83,13 +83,13 @@ public class MemberController {
 
     @Operation(
             summary = "경매관리",
-            description = "로그인한 회원의 경매를 상태별(ALL, SCHEDULED, ONGOING, SUCCESS, FAILED, CANCELLED)로 조회합니다."
+            description = "로그인한 회원의 경매를 상태별(ALL, PENDING, ONGOING, SUCCESS, FAILED, CANCELLED)로 조회합니다."
     )
     @GetMapping("/me/sales/auctions")
     public ResponseEntity<ApiResponse<MemberSalesAuctionResultResponse>> getSellingItems(
             @AuthenticationPrincipal Member member,
             @Parameter(
-                    description = "조회 타입(ALL, SCHEDULED, ONGOING, SUCCESS, FAILED, CANCELLED)",
+                    description = "조회 타입(ALL, PENDING, ONGOING, SUCCESS, FAILED, CANCELLED)",
                     example = "ONGOING"
             )
             @RequestParam String type,

--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -83,13 +83,13 @@ public class MemberController {
 
     @Operation(
             summary = "경매관리",
-            description = "로그인한 회원의 경매를 상태별(ALL, ONGOING, SUCCESS, FAILED)로 조회합니다."
+            description = "로그인한 회원의 경매를 상태별(ALL, SCHEDULED, ONGOING, SUCCESS, FAILED, CANCELLED)로 조회합니다."
     )
     @GetMapping("/me/sales/auctions")
     public ResponseEntity<ApiResponse<MemberSalesAuctionResultResponse>> getSellingItems(
             @AuthenticationPrincipal Member member,
             @Parameter(
-                    description = "조회 타입(ALL, ONGOING, SUCCESS, FAILED)",
+                    description = "조회 타입(ALL, SCHEDULED, ONGOING, SUCCESS, FAILED, CANCELLED)",
                     example = "ONGOING"
             )
             @RequestParam String type,

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -346,9 +346,11 @@ public class MemberServiceImpl implements MemberService {
         String normalizedStatus = status.toUpperCase();
 
         if (!"ALL".equals(normalizedStatus)
+                && !"PENDING".equals(normalizedStatus)
                 && !"ONGOING".equals(normalizedStatus)
                 && !"SUCCESS".equals(normalizedStatus)
-                && !"FAILED".equals(normalizedStatus)) {
+                && !"FAILED".equals(normalizedStatus)
+                && !"CANCELLED".equals(normalizedStatus)) {
             throw new CustomException(ErrorType.INVALID_AUCTION_STATUS);
         }
     }

--- a/src/main/resources/db/migration/V19__update_auction_type.sql
+++ b/src/main/resources/db/migration/V19__update_auction_type.sql
@@ -1,0 +1,10 @@
+ALTER TABLE auction
+MODIFY COLUMN `type` VARCHAR(20) NOT NULL DEFAULT 'NORMAL';
+
+UPDATE auction
+SET type = 'NORMAL'
+WHERE type = 'INSPECTION';
+
+ALTER TABLE auction
+ADD CONSTRAINT chk_auction_type
+CHECK (`type` IN ('NORMAL', 'TIME_DEAL'));

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -555,19 +555,31 @@
 <!--    경매 목록 조회-->
     <select id="findMySalesAuctions" resultType="MemberSalesAuctionResponse">
         SELECT
+        auctionId,
+        itemName,
+        currentPrice,
+        bidCount,
+        endDate,
+        auctionType,
+        saleStatus,
+        imageUrl
+        FROM (
+        SELECT
         a.id AS auctionId,
         ai.name AS itemName,
         COALESCE(a.winner_price, a.vickrey_price, a.start_price) AS currentPrice,
-        a.start_price AS startPrice,
         a.bid_count AS bidCount,
         a.end_date AS endDate,
         a.type AS auctionType,
         CASE
+        WHEN a.status = 'PENDING' THEN 'PENDING'
         WHEN a.status = 'ON_GOING' THEN 'ONGOING'
         WHEN a.status = 'ENDED' AND a.winner_id IS NOT NULL THEN 'SUCCESS'
         WHEN a.status = 'ENDED' AND a.winner_id IS NULL THEN 'FAILED'
+        WHEN a.status = 'CANCELLED' THEN 'CANCELLED'
         END AS saleStatus,
-        ii.url AS imageUrl
+        ii.url AS imageUrl,
+        a.created_at AS createdAt
         FROM auction a
         INNER JOIN auction_item ai
         ON a.item_id = ai.id
@@ -575,19 +587,15 @@
         ON ii.item_id = ai.id
         AND ii.display_order = 1
         WHERE a.seller_id = #{memberId}
-        AND a.status != 'CANCELLED'
-        AND (
-        #{type} = 'ALL'
-        OR (#{type} = 'ONGOING' AND a.status = 'ON_GOING')
-        OR (#{type} = 'SUCCESS' AND a.status = 'ENDED' AND a.winner_id IS NOT NULL)
-        OR (#{type} = 'FAILED' AND a.status = 'ENDED' AND a.winner_id IS NULL)
-        )
+        ) q
+        WHERE #{type} = 'ALL'
+        OR q.saleStatus = #{type}
         <choose>
             <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">
-                ORDER BY a.created_at ASC
+                ORDER BY q.createdAt ASC
             </when>
             <otherwise>
-                ORDER BY a.created_at DESC
+                ORDER BY q.createdAt DESC
             </otherwise>
         </choose>
         LIMIT #{pageRequest.size}
@@ -599,12 +607,13 @@
         SELECT COUNT(*)
         FROM auction a
         WHERE a.seller_id = #{memberId}
-          AND a.status != 'CANCELLED'
-      AND (
+        AND (
             #{type} = 'ALL'
+           OR (#{type} = 'PENDING' AND a.status = 'PENDING')
            OR (#{type} = 'ONGOING' AND a.status = 'ON_GOING')
            OR (#{type} = 'SUCCESS' AND a.status = 'ENDED' AND a.winner_id IS NOT NULL)
            OR (#{type} = 'FAILED' AND a.status = 'ENDED' AND a.winner_id IS NULL)
+           OR (#{type} = 'CANCELLED' AND a.status = 'CANCELLED')
             )
     </select>
 

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -626,7 +626,6 @@
             SUM(CASE WHEN a.status = 'ENDED' AND a.winner_id IS NULL THEN 1 ELSE 0 END) AS failedCount
         FROM auction a
         WHERE a.seller_id = #{memberId}
-          AND a.status != 'CANCELLED'
     </select>
 </mapper>
 


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 경매 관리 조회 API에 경매 상태 타입 추가
   - 기존: 전체, 진행중, 낙찰, 유찰
   - 추가: 경매 예정(PENDING), 취소(CANCELLED) 상태 조회 가능하도록 확장
- 상태 필터링 조건 개선
- saleStatus 기준으로 조회하도록 로직 정리
- 조회 결과에서 상태값 매핑 로직 정리 (PENDING, ONGOING, SUCCESS, FAILED, CANCELLED)