### PR TITLE
feat / refactor: 대시보드 조회 API 수정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/controller/MemberController.java
@@ -63,24 +63,6 @@ public class MemberController {
         return ApiResponse.of(HttpStatus.OK, null, "회원 탈퇴 성공", null);
     }
 
-    @GetMapping("/me/sales")
-    public ResponseEntity<ApiResponse<PageResponse<MemberSalesItemResponse>>> getSales(
-            @AuthenticationPrincipal Member member,
-            @Valid BasePageRequest pageRequest
-    ) {
-        PageResponse<MemberSalesItemResponse> result = memberService.getMySales(member.getId(), pageRequest);
-        return ApiResponse.of(HttpStatus.OK, null, "판매 내역 조회 성공", result);
-    }
-
-    @GetMapping("/me/purchases")
-    public ResponseEntity<ApiResponse<PageResponse<MemberPurchaseItemResponse>>> getPurchases(
-            @AuthenticationPrincipal Member member,
-            @Valid BasePageRequest pageRequest
-    ) {
-        PageResponse<MemberPurchaseItemResponse> result = memberService.getMyPurchases(member.getId(), pageRequest);
-        return ApiResponse.of(HttpStatus.OK, null, "구매 내역 조회 성공", result);
-    }
-
     @Operation(
             summary = "경매관리",
             description = "로그인한 회원의 경매를 상태별(ALL, ONGOING, SUCCESS, FAILED)로 조회합니다."

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberBiddingItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberBiddingItemResponse.java
@@ -10,9 +10,22 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberBiddingItemResponse {
+
+    // 상품 대표 이미지 URL
     private String imageUrl;
+
+    // 상품명
     private String itemName;
+
+    // 현재가
     private Long currentPrice;
+
+    // 내 입찰가
     private Long myBidPrice;
+
+    // 경매 종료 일시
     private LocalDateTime endDate;
+
+    // 경매 상태
+    private String status;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberDashboardResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberDashboardResponse.java
@@ -18,11 +18,14 @@ public class MemberDashboardResponse {
     private String nickname;
     private String grade;
     private Long point;
+    private String imageUrl;
 
-    // 낙찰된 물품 목록
-    private List<MemberWonItemResponse> wonItems;
+    // 진행 중인 구매 현황
+    private List<MemberWonItemResponse> purchaseItems;
 
-    // 입찰 중 물품 목록
+    // 진행 중인 판매 현황
+    private List<MemberSalesItemResponse> salesItems;
+
+    // 입찰 내역
     private List<MemberBiddingItemResponse> biddingItems;
-
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesItemResponse.java
@@ -13,9 +13,6 @@ import java.time.LocalDateTime;
 @Builder
 public class MemberSalesItemResponse {
 
-    // 상품 대표 이미지 URL
-    private String imageUrl;
-
     // 상품명
     private String itemName;
 

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberSalesItemResponse.java
@@ -13,9 +13,18 @@ import java.time.LocalDateTime;
 @Builder
 public class MemberSalesItemResponse {
 
+    // 상품 대표 이미지 URL
+    private String imageUrl;
+
+    // 상품명
     private String itemName;
-    private String buyerName;
-    private Long price;
-    private LocalDateTime completedAt;
-    private String deliveryStatus;
+
+    // 거래 상태
+    private String status;
+
+    // 판매 금액
+    private Long winnerPrice;
+
+    // 거래 생성일
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberWonItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberWonItemResponse.java
@@ -5,12 +5,26 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MemberWonItemResponse {
+
+    // 상품 대표 이미지 URL
     private String imageUrl;
+
+    // 상품명
     private String itemName;
-    private String deliveryStatus;
+
+    // 거래 상태
+    private String status;
+
+    // 낙찰 금액 (구매 금액)
+    private Long winnerPrice;
+
+    // 구매 일시 (거래 생성 시점)
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/biddingmate/biddinggo/member/dto/MemberWonItemResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/dto/MemberWonItemResponse.java
@@ -13,9 +13,6 @@ import java.time.LocalDateTime;
 @Builder
 public class MemberWonItemResponse {
 
-    // 상품 대표 이미지 URL
-    private String imageUrl;
-
     // 상품명
     private String itemName;
 

--- a/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/mapper/MemberMapper.java
@@ -32,14 +32,17 @@ public interface MemberMapper extends IMybatisCRUD<Member> {
 
     MemberProfileResponse findProfileById(@Param("memberId") Long memberId);
 
-    // 대시보드
+    // 대시보드 프로필 기본 정보
     MemberDashboardResponse findDashboardInfoById(@Param("memberId") Long memberId);
 
-    // 낙찰된 물품 목록
-    List<MemberWonItemResponse> findWonItemsById(@Param("memberId") Long memberId);
+    // 진행 중 구매 현황
+    List<MemberWonItemResponse> findPurchaseItemsById(@Param("memberId") Long memberId);
 
-    // 입찰 중 물품 목록
+    // 입찰 내역
     List<MemberBiddingItemResponse> findBiddingItemsById(@Param("memberId") Long memberId);
+
+    // 진행 중 판매 현황
+    List<MemberSalesItemResponse> findSalesItemsById(@Param("memberId") Long memberId);
 
     // 아이디를 통한 사용자 조회(auth)
     Member selectMemberByUsername(@Param("username") String username);

--- a/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/member/service/MemberServiceImpl.java
@@ -45,13 +45,16 @@ public class MemberServiceImpl implements MemberService {
         // 회원 존재 여부 체크
         memberExists(memberId);
 
-        // 회원 정보 조회
+        // 회원 정보 기본 조회
         MemberDashboardResponse summary = memberMapper.findDashboardInfoById(memberId);
 
-        // 낙찰된 물품 목록 조회
-        List<MemberWonItemResponse> wonItems = memberMapper.findWonItemsById(memberId);
+        // 진행 중인 구매 현황 조회
+        List<MemberWonItemResponse> purchaseItems = memberMapper.findPurchaseItemsById(memberId);
 
-        // 입찰 중인 물품 목록 조회
+        // 진행 중인 판매 현황 조회
+        List<MemberSalesItemResponse> salesItems = memberMapper.findSalesItemsById(memberId);
+
+        // 입찰 내역 조회
         List<MemberBiddingItemResponse> biddingItems = memberMapper.findBiddingItemsById(memberId);
 
         // 대시보드 응답 DTO
@@ -59,8 +62,10 @@ public class MemberServiceImpl implements MemberService {
                 .nickname(summary.getNickname())
                 .grade(summary.getGrade())
                 .point(summary.getPoint())
-                .wonItems(wonItems)
+                .imageUrl(summary.getImageUrl())
+                .purchaseItems(purchaseItems)
                 .biddingItems(biddingItems)
+                .salesItems(salesItems)
                 .build();
     }
 

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -22,15 +22,18 @@
     <select id="findDashboardInfoById" parameterType="long" resultType="MemberDashboardResponse">
         SELECT  m.nickname AS nickname,
                 m.grade AS grade,
-                m.point AS POINT
+                m.point AS point,
+                m.image_url AS imageUrl
         FROM member m
         WHERE m.id = #{memberId}
     </select>
 
-    <select id="findWonItemsById" parameterType="long" resultType="MemberWonItemResponse">
+    <select id="findPurchaseItemsById" parameterType="long" resultType="MemberWonItemResponse">
         SELECT  ii.url AS imageUrl,                     -- 상품 대표 이미지 URL
                 ai.name AS itemName,                    -- 상품 이름
-                wd.delivery_status AS deliveryStatus    -- 배송 상태
+                wd.status AS status,                    -- 거래 상태
+                wd.winner_price AS winnerPrice,         -- 구매 금액
+                wd.created_at AS createdAt             -- 거래 생성일
         FROM winner_deal wd
 
         -- 낙찰된 경매 정보 연결
@@ -47,18 +50,20 @@
         AND ii.`display_order` = 1              -- 대표 이미지 1장만
 
         WHERE wd.winner_id = #{memberId}
-        AND wd.status IN ('PAID', 'CONFIRMED')  -- 배송 취소 상태 제외
+
+        AND wd.status IN ('PAID', 'SHIPPED')
         ORDER BY wd.created_at DESC             -- 최신순
-        LIMIT 2
+        LIMIT 3                                 -- 최근 3건만 노출
     </select>
 
     <select id="findBiddingItemsById" parameterType="long" resultType="MemberBiddingItemResponse">
         SELECT
             ii.url AS imageUrl,                 -- 상품 대표 이미지 URL
             ai.name AS itemName,                -- 상품 이름
-            a.vickrey_price AS currentPrice,    -- 차순위 가격
+            COALESCE(a.vickrey_price, a.start_price) AS currentPrice, -- 현재가(차순위가 없으면 시작가)
             mb.myBidPrice AS myBidPrice,        -- 내가 해당 경매에서 입찰한 최고 금액
-            a.end_date AS endDate               -- 경매 종료일
+            a.end_date AS endDate,              -- 경매 종료일
+            a.status AS status                  -- 경매 상태
         FROM (                                  -- 한 경매에 여러 번 입찰 가능, MAX()로 "내 최고 입찰가" 뽑기
                  SELECT
                      b.auction_id,
@@ -78,9 +83,8 @@
                            ON ii.item_id = ai.id
                                AND ii.`display_order` = 1
 
-        WHERE a.status = 'ON_GOING'
-        ORDER BY a.end_date ASC
-        LIMIT 3
+        ORDER BY a.end_date DESC
+        LIMIT 2
     </select>
 
     <select id="findById" parameterType="long" resultType="Member">
@@ -315,34 +319,39 @@
         WHERE id = #{memberId}
     </update>
 
-<select id="findSalesByMember" resultType="MemberSalesItemResponse">
+<select id="findSalesItemsById" parameterType="long" resultType="MemberSalesItemResponse">
     SELECT
-        ai.name AS itemName,                   -- 상품명
-        buyer.name AS buyerName,              -- 구매자 이름
-        wd.winner_price AS price,             -- 판매 금액
-        wd.confirmed_at AS completedAt,       -- 거래 완료 날짜
-        wd.delivery_status AS deliveryStatus  -- 배송 상태
+        ii.url AS imageUrl,             -- 상품 대표 이미지 URL
+        ai.name AS itemName,            -- 상품명
+        wd.status AS status,            -- 거래 상태
+        wd.winner_price AS winnerPrice, -- 판매 금액(낙찰 금액)
+        wd.created_at AS createdAt      -- 거래 생성일
     FROM winner_deal wd
+
+    -- 거래와 연결된 경매 정보 조회
     INNER JOIN auction a
-        ON wd.auction_id = a.id
+    ON wd.auction_id = a.id
+
+    -- 경매에 연결된 상품 정보 조회
     INNER JOIN auction_item ai
-        ON a.item_id = ai.id
-    INNER JOIN member buyer
-        ON wd.winner_id = buyer.id
+    ON a.item_id = ai.id
+
+    -- 상품 대표 이미지 1장만 조회
+    LEFT JOIN item_image ii
+    ON ii.item_id = ai.id
+    AND ii.display_order = 1
+
+    -- 해당 회원이 판매자인 거래만 조회
     WHERE wd.seller_id = #{memberId}
-      AND wd.status IN ('PAID', 'CONFIRMED')
 
-    <choose>
-        <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">
-            ORDER BY wd.confirmed_at ASC
-        </when>
-        <otherwise>
-            ORDER BY wd.confirmed_at DESC
-        </otherwise>
-    </choose>
+    -- 진행 중인 판매 현황만 조회
+    AND wd.status IN ('PAID', 'SHIPPED', 'CONFIRMED')
 
-    LIMIT #{pageRequest.size}
-    OFFSET #{pageRequest.offset}
+    -- 최신 거래 순으로 정렬
+    ORDER BY wd.created_at DESC
+
+    -- 3건만 노출
+    LIMIT 3
 </select>
 
 <select id="countSalesByMemberId" resultType="long">
@@ -367,7 +376,7 @@
     INNER JOIN member seller
         ON wd.seller_id = seller.id
     WHERE wd.winner_id = #{memberId}
-      AND wd.status IN ('PAID', 'CONFIRMED')
+      AND wd.status IN ('PAID', 'CONFIRMED', 'CONFIRMED')
 
     <choose>
         <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -29,7 +29,7 @@
     </select>
 
     <select id="findPurchaseItemsById" parameterType="long" resultType="MemberWonItemResponse">
-        SELECT  ii.url AS imageUrl,                     -- 상품 대표 이미지 URL
+        SELECT
                 ai.name AS itemName,                    -- 상품 이름
                 wd.status AS status,                    -- 거래 상태
                 wd.winner_price AS winnerPrice,         -- 구매 금액
@@ -44,14 +44,9 @@
         INNER JOIN auction_item ai
         ON a.item_id = ai.id
 
-        -- 상품 이미지
-        LEFT JOIN item_image ii
-        ON ii.item_id = ai.id
-        AND ii.`display_order` = 1              -- 대표 이미지 1장만
-
         WHERE wd.winner_id = #{memberId}
 
-        AND wd.status IN ('PAID', 'SHIPPED')
+        AND wd.status != 'CANCELLED'
         ORDER BY wd.created_at DESC             -- 최신순
         LIMIT 3                                 -- 최근 3건만 노출
     </select>
@@ -321,7 +316,6 @@
 
 <select id="findSalesItemsById" parameterType="long" resultType="MemberSalesItemResponse">
     SELECT
-        ii.url AS imageUrl,             -- 상품 대표 이미지 URL
         ai.name AS itemName,            -- 상품명
         wd.status AS status,            -- 거래 상태
         wd.winner_price AS winnerPrice, -- 판매 금액(낙찰 금액)
@@ -336,16 +330,11 @@
     INNER JOIN auction_item ai
     ON a.item_id = ai.id
 
-    -- 상품 대표 이미지 1장만 조회
-    LEFT JOIN item_image ii
-    ON ii.item_id = ai.id
-    AND ii.display_order = 1
-
     -- 해당 회원이 판매자인 거래만 조회
     WHERE wd.seller_id = #{memberId}
 
     -- 진행 중인 판매 현황만 조회
-    AND wd.status IN ('PAID', 'SHIPPED', 'CONFIRMED')
+    AND wd.status != 'CANCELLED'
 
     -- 최신 거래 순으로 정렬
     ORDER BY wd.created_at DESC
@@ -376,7 +365,7 @@
     INNER JOIN member seller
         ON wd.seller_id = seller.id
     WHERE wd.winner_id = #{memberId}
-      AND wd.status IN ('PAID', 'CONFIRMED', 'CONFIRMED')
+      AND wd.status IN ('PAID', 'CONFIRMED')
 
     <choose>
         <when test="pageRequest.order != null and pageRequest.order.toUpperCase() == 'ASC'">


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [x] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 회원 마이페이지(대시보드) 조회 기능 개선 및 확장
- 대시보드 응답 구조를 구매, 판매, 입찰 내역으로 분리하여 조회하도록 변경
- 회원 프로필 정보(닉네임, 등급, 포인트, 이미지)를 대시보드 응답에 포함
- 진행 중 구매/판매 현황에 거래 상태(PAID, SHIPPED, CONFIRMED), 거래 금액, 거래 일자 정보가 함께 조회되도록 추가
- 입찰 내역이 기존 “진행 중” 기준에서 전체 상태(ON_GOING, ENDED 등)를 포함하도록 변경
- 기존 판매/구매 내역 조회 API 제거

---

## 📎 관련 이슈

- close #221 
