### PR TITLE
refactor: 판매자 정보 조회 API 수정 및 리뷰 작성 로직 강화

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/service/AuctionServiceImpl.java
@@ -1,24 +1,22 @@
 package com.biddingmate.biddinggo.auction.service;
 
-import com.biddingmate.biddinggo.auction.dto.BidCountDto;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionFromInspectionItemRequest;
 import com.biddingmate.biddinggo.auction.dto.CreateAuctionRequest;
 import com.biddingmate.biddinggo.auction.dto.UpdateAuctionRequest;
 import com.biddingmate.biddinggo.auction.event.AuctionCancelledEvent;
-import com.biddingmate.biddinggo.auction.prediction.event.AuctionQueryEmbeddingSyncRequestedEvent;
-import com.biddingmate.biddinggo.auction.prediction.model.AuctionEmbeddingSyncTrigger;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auction.model.AuctionStatus;
 import com.biddingmate.biddinggo.auction.model.YesNo;
+import com.biddingmate.biddinggo.auction.prediction.event.AuctionQueryEmbeddingSyncRequestedEvent;
+import com.biddingmate.biddinggo.auction.prediction.model.AuctionEmbeddingSyncTrigger;
 import com.biddingmate.biddinggo.bid.model.Bid;
 import com.biddingmate.biddinggo.bid.service.BidQueryService;
 import com.biddingmate.biddinggo.bid.service.BidService;
 import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
-import com.biddingmate.biddinggo.item.service.AuctionItemService;
 import com.biddingmate.biddinggo.item.model.AuctionItem;
-import com.biddingmate.biddinggo.member.model.MemberStatus;
+import com.biddingmate.biddinggo.item.service.AuctionItemService;
 import com.biddingmate.biddinggo.point.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -150,6 +150,7 @@ public enum ErrorType {
     REVIEW_DELETE_FAIL("review-004", "리뷰 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     NOT_THE_WINNER("review-005", "낙찰자만 해당 경매의 리뷰를 남길 수 있습니다.", HttpStatus.FORBIDDEN),
     SELLER_NOT_FOUND("review-006", "해당 경매의 판매자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    WINNER_DEAL_NOT_CONFIRMED("review-007", "구매 확정된 거래에 대해서만 리뷰를 작성할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
     // 알림
     NOTIFICATION_SAVE_FAILED("notification-001", "알림 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/biddingmate/biddinggo/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/review/service/ReviewServiceImpl.java
@@ -14,6 +14,7 @@ import com.biddingmate.biddinggo.review.dto.SellerReviewResponse;
 import com.biddingmate.biddinggo.review.mapper.ReviewMapper;
 import com.biddingmate.biddinggo.review.model.Review;
 import com.biddingmate.biddinggo.winnerdeal.mapper.WinnerDealMapper;
+import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +50,10 @@ public class ReviewServiceImpl implements ReviewService {
         var deal = winnerDealMapper.findByAuctionId(auctionId);
         if (deal == null) {
             throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
+        }
+
+        if (deal.getStatus() != WinnerDealStatus.CONFIRMED) {
+            throw new CustomException(ErrorType.WINNER_DEAL_NOT_CONFIRMED);
         }
 
         // 중복 리뷰 방지

--- a/src/main/resources/mapper/member/member-mapper.xml
+++ b/src/main/resources/mapper/member/member-mapper.xml
@@ -497,7 +497,7 @@
             (SELECT COUNT(*)
              FROM winner_deal
              WHERE seller_id = #{memberId}
-               AND status IN ('PAID', 'CONFIRMED')) AS totalSales,
+               AND status IN ('PAID','SHIPPED','CONFIRMED')) AS totalSales,
 
             -- 판매 취소 건수
             (SELECT COUNT(*)


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [X] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- winner_deal 테이블의 status에 SHIPPED 상태가 추가됨에 따라, 판매자 통계 조회 쿼리에서 성공한 거래의 범위를 PAID, SHIPPED, CONFIRMED로 확장하였습니다.
- 기존에는 낙찰 직후 리뷰 작성이 가능했으나 데이터 신뢰도를 위해 오직 구매 확정 상태의 거래에 대해서만 리뷰를 작성할 수 있도록 서비스 로직을 강화했습니다.
- 구매 확정 전 리뷰 작성을 시도할 경우 WINNER_DEAL_NOT_CONFIRMED 에러를 반환합니다.

---

## 📎 관련 이슈
close #208 