### PR TITLE
feat: 검수 전 운송 정보 검증 및 알림 발송 구현

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
+++ b/src/main/java/com/biddingmate/biddinggo/common/exception/ErrorType.java
@@ -73,6 +73,7 @@ public enum ErrorType {
     INVALID_INSPECTION_LIST_REQUEST("inspection-007", "검수물품 목록 조회 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_INSPECTION_LIST_STATUS("inspection-008", "검수물품 상태값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     ALREADY_INSPECTION_STATUS("inspection-009", "이미 검수 완료된 물품입니다.", HttpStatus.CONFLICT),
+    INSPECTION_SHIPPING_INFO_REQUIRED("inspection-010", "운송장 정보가 등록된 검수만 처리할 수 있습니다.", HttpStatus.CONFLICT),
 
     // 파일
     INVALID_FILE_UPLOAD_REQUEST("file-001", "파일 업로드 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/biddingmate/biddinggo/inspection/controller/AdminInspectionController.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/controller/AdminInspectionController.java
@@ -11,6 +11,7 @@ import com.biddingmate.biddinggo.inspection.service.InspectionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,7 +44,7 @@ public class AdminInspectionController {
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "관리자용 검수 처리", description = "관리자가 검수 신청을 처리합니다.")
     public ResponseEntity<ApiResponse<Void>> processInspection(@Parameter(description = "검수 ID", example = "1") @PathVariable Long inspectionId,
-                                                               @RequestBody InspectionProcessRequest request) {
+                                                               @Valid @RequestBody InspectionProcessRequest request) {
         inspectionService.processInspection(inspectionId, request);
 
         return ApiResponse.of(HttpStatus.OK, null, "관리자 검수 처리 성공", null);

--- a/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionProcessRequest.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/dto/InspectionProcessRequest.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.inspection.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,8 @@ import lombok.Getter;
 @Schema(description = "관리자용 검수 처리 요청 DTO")
 public class InspectionProcessRequest {
     @Schema(description = "검수 승인 여부", example = "true")
-    private boolean approved;
+    @NotNull(message = "검수 승인 여부는 필수입니다.")
+    private Boolean approved;
     @Schema(description = "검수 품질", example = "최상", nullable = true)
     private String quality;
     @Schema(description = "검수 실패 사유", example = "오염/스크래치", nullable = true)

--- a/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/inspection/service/InspectionServiceImpl.java
@@ -9,39 +9,32 @@ import com.biddingmate.biddinggo.inspection.mapper.InspectionMapper;
 import com.biddingmate.biddinggo.inspection.model.Inspection;
 import com.biddingmate.biddinggo.inspection.model.InspectionStatus;
 import com.biddingmate.biddinggo.item.mapper.AuctionItemMapper;
-import com.biddingmate.biddinggo.item.model.AuctionItemStatus;
+import com.biddingmate.biddinggo.item.model.AuctionItem;
 import com.biddingmate.biddinggo.item.model.ItemInspectionStatus;
-import com.biddingmate.biddinggo.item.service.AuctionItemService;
+import com.biddingmate.biddinggo.notification.model.NotificationType;
+import com.biddingmate.biddinggo.notification.service.NotificationPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
-/**
- * inspection 엔티티 생성만 담당하는 서비스 구현체.
- * 트랜잭션은 상위 애플리케이션 서비스에서 시작된 흐름에 참여한다.
- */
 @Service
 @RequiredArgsConstructor
 public class InspectionServiceImpl implements InspectionService {
     private final InspectionMapper inspectionMapper;
     private final AuctionItemMapper auctionItemMapper;
+    private final NotificationPublisher notificationPublisher;
 
     @Override
-    /**
-     * 검수 대상 itemId를 기준으로 inspection 레코드를 생성한다.
-     * 최초 등록 상태는 항상 PENDING으로 시작한다.
-     */
     public Long createInspection(CreateInspectionRequest request, Long itemId) {
         if (itemId == null) {
             throw new CustomException(ErrorType.INVALID_INSPECTION_CREATE_REQUEST);
         }
 
-        // 검수 발송 정보는 선택 입력이므로 null 여부를 분기해서 사용한다.
         CreateInspectionRequest.Inspection inspectionRequest = request.getInspection();
 
-        // inspection 테이블 저장용 모델로 변환한다.
         Inspection inspection = Inspection.builder()
                 .itemId(itemId)
                 .status(InspectionStatus.PENDING)
@@ -50,7 +43,6 @@ public class InspectionServiceImpl implements InspectionService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        // inspection 저장 후 생성된 PK를 모델에 주입받는다.
         int inspectionInsertCount = inspectionMapper.insert(inspection);
 
         if (inspectionInsertCount != 1 || inspection.getId() == null) {
@@ -61,10 +53,6 @@ public class InspectionServiceImpl implements InspectionService {
     }
 
     @Override
-    /**
-     * 검수 배송 정보(택배사, 송장 번호)를 사후 등록한다.
-     * 배송 정보는 PENDING 상태의 검수에만 최초 1회 등록 가능하다.
-     */
     public void updateShippingInfo(Long inspectionId, UpdateInspectionShippingRequest request) {
         Inspection inspection = inspectionMapper.findById(inspectionId);
 
@@ -95,34 +83,58 @@ public class InspectionServiceImpl implements InspectionService {
     @Override
     @Transactional
     public void processInspection(Long inspectionId, InspectionProcessRequest request) {
-        // 검수 조회
         Inspection inspection = inspectionMapper.findById(inspectionId);
         if (inspection == null) {
             throw new CustomException(ErrorType.INSPECTION_NOT_FOUND);
         }
 
-        // 이미 처리된 검수인지 체크
-        if (!inspection.getStatus().equals(InspectionStatus.PENDING)) {
+        if (inspection.getStatus() != InspectionStatus.PENDING) {
             throw new CustomException(ErrorType.ALREADY_INSPECTION_STATUS);
         }
 
-        boolean approved = request.isApproved();
+        if (!StringUtils.hasText(inspection.getCarrier()) || !StringUtils.hasText(inspection.getTrackingNumber())) {
+            throw new CustomException(ErrorType.INSPECTION_SHIPPING_INFO_REQUIRED);
+        }
 
-        // 검수 상태 결정
+        boolean approved = request.getApproved();
+
         InspectionStatus status = approved
                 ? InspectionStatus.PASSED
                 : InspectionStatus.FAILED;
 
-        // 검수 상태 업데이트
         inspectionMapper.updateStatus(inspectionId, status, InspectionStatus.PENDING, request.getFailureReason());
 
-        // 물품에 대한 복사본?
         Long auctionItemId = inspection.getItemId();
 
         ItemInspectionStatus itemStatus = approved
                 ? ItemInspectionStatus.PASSED
                 : ItemInspectionStatus.FAILED;
 
-        auctionItemMapper.updateInspectionStatus(auctionItemId, itemStatus, ItemInspectionStatus.PENDING, request.getQuality());
+        auctionItemMapper.updateInspectionStatus(
+                auctionItemId,
+                itemStatus,
+                ItemInspectionStatus.PENDING,
+                request.getQuality()
+        );
+
+        AuctionItem auctionItem = auctionItemMapper.findById(auctionItemId);
+        if (auctionItem != null && auctionItem.getSellerId() != null) {
+            String itemName = StringUtils.hasText(auctionItem.getName())
+                    ? auctionItem.getName()
+                    : "검수 물품";
+
+            String notificationContent = approved
+                    ? "[" + itemName + "] 검수가 승인되었습니다."
+                    : StringUtils.hasText(request.getFailureReason())
+                    ? "[" + itemName + "] 검수가 반려되었습니다. 사유: " + request.getFailureReason()
+                    : "[" + itemName + "] 검수가 반려되었습니다.";
+
+            notificationPublisher.publishNotification(
+                    auctionItem.getSellerId(),
+                    NotificationType.INSPECTION,
+                    notificationContent,
+                    "/inspections/" + inspectionId
+            );
+        }
     }
 }

--- a/src/main/java/com/biddingmate/biddinggo/notification/model/NotificationType.java
+++ b/src/main/java/com/biddingmate/biddinggo/notification/model/NotificationType.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.notification.model;
 
 public enum NotificationType {
+    INSPECTION,
     DELIVERY,
     WIN,
     NEW_BID,


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [ ] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 관리자 검수 처리 요청 DTO에 `approved` 필수 검증을 추가했습니다.
- 관리자 검수 처리 API에 `@Valid`를 적용해 요청값 검증이 동작하도록 수정했습니다.
- 검수 처리 전 `inspection`의 `carrier`, `tracking_number` 등록 여부를 검증하도록 구현했습니다.
- 운송 정보가 없는 경우 `INSPECTION_SHIPPING_INFO_REQUIRED` 예외를 반환하도록 `ErrorType`을 추가했습니다.
- 검수 승인/반려 처리 후 판매자에게 알림이 발송되도록 구현했습니다.
- 알림 문구가 상품명을 기준으로 노출되도록 정리했습니다.
- 검수 결과 알림 유형으로 `NotificationType.INSPECTION`을 추가했습니다.

---

## 📎 관련 이슈
- #239 