### PR TITLE
fix: inspection_yn 기준으로 관리자 운송장 등록 및 검수 판별 정리

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/auction/model/AuctionType.java
+++ b/src/main/java/com/biddingmate/biddinggo/auction/model/AuctionType.java
@@ -1,7 +1,6 @@
 package com.biddingmate.biddinggo.auction.model;
 
 public enum AuctionType {
-    INSPECTION,
     NORMAL,
     TIME_DEAL
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailQueryResult.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailQueryResult.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.winnerdeal.dto;
 
 import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.auction.model.YesNo;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
 import lombok.Getter;
 
@@ -15,6 +16,7 @@ public class AdminWinnerDealDetailQueryResult {
     private String itemName;
     private String itemImageUrl;
     private AuctionType auctionType;
+    private YesNo inspectionYn;
     private WinnerDealStatus status;
     private Long winnerPrice;
     private String sellerName;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealDetailResponse.java
@@ -1,6 +1,7 @@
 package com.biddingmate.biddinggo.winnerdeal.dto;
 
 import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.auction.model.YesNo;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,9 @@ public class AdminWinnerDealDetailResponse {
 
     @Schema(description = "경매 타입", example = "INSPECTION")
     private AuctionType auctionType;
+
+    @Schema(description = "검수 경매 여부", example = "YES")
+    private YesNo inspectionYn;
 
     @Schema(description = "검수 물품 여부", example = "true")
     private Boolean inspectionItem;

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/dto/AdminWinnerDealListResponse.java
@@ -1,5 +1,6 @@
 package com.biddingmate.biddinggo.winnerdeal.dto;
 
+import com.biddingmate.biddinggo.auction.model.YesNo;
 import com.biddingmate.biddinggo.winnerdeal.model.WinnerDealStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -36,4 +37,7 @@ public class AdminWinnerDealListResponse {
 
     @Schema(description = "거래 상태", example = "SHIPPED")
     private WinnerDealStatus status;
+
+    @Schema(description = "검수 경매 여부", example = "YES")
+    private YesNo inspectionYn;
 }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealQueryServiceImpl.java
@@ -4,7 +4,7 @@ import com.biddingmate.biddinggo.common.exception.CustomException;
 import com.biddingmate.biddinggo.common.exception.ErrorType;
 import com.biddingmate.biddinggo.common.response.PageResponse;
 import com.biddingmate.biddinggo.review.mapper.ReviewMapper;
-import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.auction.model.YesNo;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailQueryResult;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealDetailResponse;
 import com.biddingmate.biddinggo.winnerdeal.dto.AdminWinnerDealListRequest;
@@ -149,7 +149,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
             throw new CustomException(ErrorType.WINNER_DEAL_NOT_FOUND);
         }
 
-        boolean inspectionItem = detail.getAuctionType() == AuctionType.INSPECTION;
+        boolean inspectionItem = detail.getInspectionYn() == YesNo.YES;
         boolean shippingAddressRegistered = isShippingAddressRegistered(detail);
         boolean trackingNumberRegistered = isTrackingNumberRegistered(detail);
 
@@ -161,6 +161,7 @@ public class WinnerDealQueryServiceImpl implements WinnerDealQueryService {
                 .itemName(detail.getItemName())
                 .itemImageUrl(detail.getItemImageUrl())
                 .auctionType(detail.getAuctionType())
+                .inspectionYn(detail.getInspectionYn())
                 .inspectionItem(inspectionItem)
                 .status(detail.getStatus())
                 .winnerPrice(detail.getWinnerPrice())

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -4,7 +4,7 @@ import com.biddingmate.biddinggo.auction.dto.RefundDto;
 import com.biddingmate.biddinggo.auction.mapper.AuctionMapper;
 import com.biddingmate.biddinggo.auction.model.Auction;
 import com.biddingmate.biddinggo.auction.model.AuctionStatus;
-import com.biddingmate.biddinggo.auction.model.AuctionType;
+import com.biddingmate.biddinggo.auction.model.YesNo;
 import com.biddingmate.biddinggo.auction.prediction.event.AuctionPriceReferenceSyncRequestedEvent;
 import com.biddingmate.biddinggo.bid.dto.BidResponse;
 import com.biddingmate.biddinggo.bid.mapper.BidMapper;
@@ -343,7 +343,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
         }
 
-        if (auction.getType() != AuctionType.INSPECTION
+        if (auction.getInspectionYn() != YesNo.YES
                 || winnerDeal.getStatus() != WinnerDealStatus.PAID
                 || !isShippingInfoRegistered(winnerDeal)
                 || isTrackingNumberRegistered(winnerDeal)) {

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -344,9 +344,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
         }
 
         if (auction.getInspectionYn() != YesNo.YES
-                || winnerDeal.getStatus() != WinnerDealStatus.PAID
-                || !isShippingInfoRegistered(winnerDeal)
-                || isTrackingNumberRegistered(winnerDeal)) {
+                || winnerDeal.getStatus() != WinnerDealStatus.PAID) {
             throw new CustomException(ErrorType.WINNER_DEAL_TRACKING_NUMBER_REGISTRATION_NOT_ALLOWED);
         }
 

--- a/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
+++ b/src/main/resources/mapper/winnerdeal/winnerdeal-mapper.xml
@@ -284,7 +284,8 @@
                ai.name AS itemName,
                wd.winner_price AS winnerPrice,
                wd.created_at AS createdAt,
-               wd.status AS status
+               wd.status AS status,
+               a.inspection_yn AS inspectionYn
         FROM winner_deal wd
         JOIN auction a ON wd.auction_id = a.id
         JOIN auction_item ai ON a.item_id = ai.id
@@ -326,6 +327,7 @@
                ai.name AS itemName,
                ii.url AS itemImageUrl,
                a.type AS auctionType,
+               a.inspection_yn AS inspectionYn,
                wd.status AS status,
                wd.winner_price AS winnerPrice,
                seller.nickname AS sellerName,


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 검수 판별 기준을 `auction.type`에서 `auction.inspection_yn`으로 변경했습니다.
- 관리자 거래 목록/상세 응답에 `inspectionYn` 필드를 추가했습니다.
- 관리자 운송장 등록 조건을 `inspection_yn=YES && status=PAID` 기준으로 정리했습니다.

---

## 📎 관련 이슈
닫고 싶은 이슈가 있다면 아래에 키워드로 연결하세요.

예: `close #123`, `fixes #45`, `resolves #67`
