### PR TITLE
bug: 구매확정 로직 및 메서드와 쿼리 수정

### DIFF
--- a/src/main/java/com/biddingmate/biddinggo/bid/mapper/BidMapper.java
+++ b/src/main/java/com/biddingmate/biddinggo/bid/mapper/BidMapper.java
@@ -46,6 +46,9 @@ public interface BidMapper extends IMybatisCRUD<Bid> {
     Long findMaxBidAmountByAuctionAndBidder(@Param("auctionId") Long auctionId,
                                             @Param("bidderId") Long memberId);
 
+    Long findMaxBidAmountByAuctionAndBidder2(@Param("auctionId") Long auctionId,
+                                             @Param("bidderId") Long bidderId);
+
     // 비활성화 처리 과정에서 bid 상태가 이미 INACTIVE로 바뀔 수 있으므로 상태와 무관하게 최고 입찰금을 조회.
     Long findMaxBidAmountByAuctionAndBidderRegardlessStatus(@Param("auctionId") Long auctionId,
                                                             @Param("bidderId") Long bidderId);

--- a/src/main/java/com/biddingmate/biddinggo/bid/service/BidQueryService.java
+++ b/src/main/java/com/biddingmate/biddinggo/bid/service/BidQueryService.java
@@ -15,6 +15,8 @@ public interface BidQueryService {
 
     Long findMaxBidAmountByAuctionAndBidder(Long auctionId, Long memberId);
 
+    Long findMaxBidAmountByAuctionAndBidder2(Long auctionId, Long memberId);
+
     Long findMaxBidAmountByAuctionAndBidderRegardlessStatus(Long auctionId, Long bidderId);
 
     List<RefundDto> findRefundTargetsExcludingWinner(Long auctionId, Long winnerId);

--- a/src/main/java/com/biddingmate/biddinggo/bid/service/BidQueryServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/bid/service/BidQueryServiceImpl.java
@@ -51,6 +51,12 @@ public class BidQueryServiceImpl implements BidQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    public Long findMaxBidAmountByAuctionAndBidder2(Long auctionId, Long memberId) {
+        return bidMapper.findMaxBidAmountByAuctionAndBidder2(auctionId, memberId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Long findMaxBidAmountByAuctionAndBidderRegardlessStatus(Long auctionId, Long bidderId) {
         return bidMapper.findMaxBidAmountByAuctionAndBidderRegardlessStatus(auctionId, bidderId);
     }

--- a/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
+++ b/src/main/java/com/biddingmate/biddinggo/winnerdeal/service/WinnerDealServiceImpl.java
@@ -378,7 +378,7 @@ public class WinnerDealServiceImpl implements WinnerDealService {
             throw new CustomException(ErrorType.WINNER_DEAL_CONFIRM_FAILED);
         }
 
-        Long maxBidAmount = bidQueryService.findMaxBidAmountByAuctionAndBidder(winnerDeal.getAuctionId(), memberId);
+        Long maxBidAmount = bidQueryService.findMaxBidAmountByAuctionAndBidder2(winnerDeal.getAuctionId(), memberId);
         long reservedAmount = maxBidAmount != null && maxBidAmount >= winnerDeal.getWinnerPrice()
                 ? maxBidAmount
                 : winnerDeal.getWinnerPrice();

--- a/src/main/resources/mapper/bid/bid-mapper.xml
+++ b/src/main/resources/mapper/bid/bid-mapper.xml
@@ -156,6 +156,13 @@
           AND status = 'INACTIVE'
     </select>
 
+    <select id="findMaxBidAmountByAuctionAndBidder2" parameterType="map" resultType="long">
+        SELECT MAX(amount)
+        FROM bid
+        WHERE auction_id = #{auctionId}
+          AND bidder_id = #{bidderId}
+    </select>
+
     <!-- 비활성화 처리 과정에서 bid 상태가 이미 INACTIVE로 바뀔 수 있으므로 상태와 무관하게 최고 입찰금을 조회한다. -->
     <select id="findMaxBidAmountByAuctionAndBidderRegardlessStatus" parameterType="map" resultType="long">
         SELECT MAX(amount)


### PR DESCRIPTION
## 📌 PR 유형
- [ ] Feature (새로운 기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- 구매확정에서 사용하는 최고 입찰가 조회를 별도 메서드로 분리
- `confirmPurchase()`가 기존 `INACTIVE` 전용 조회 대신 새 조회 메서드를 사용하도록 변경
- bid mapper/xml, query service 계층에 구매확정 전용 조회 연결

---

## 📎 관련 이슈
- #252